### PR TITLE
feat(to_honeybee): Methods to transfer extension properties to_honeybee

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
   - stage: deploy
     if: branch = master AND (NOT type IN (pull_request))
     before_install:
-    - npm i -g npm@6.6.0
+    - nvm install lts/* --latest-npm
     python:
     - "3.6"
     install:

--- a/dragonfly/building.py
+++ b/dragonfly/building.py
@@ -270,8 +270,8 @@ class Building(_BaseGeometry):
                 If None, no splitting will occur. Default: None.
         """
         if use_multiplier:
-            hb_rooms = [room for story in self._unique_stories
-                        for room in story.to_honeybee(True, tolerance)]
+            hb_rooms = [room.to_honeybee(story.multiplier, tolerance)
+                        for story in self._unique_stories for room in story]
         else:
             hb_rooms = [room.to_honeybee(1, tolerance) for room in self.all_room_2ds]
         return Model(self.display_name, hb_rooms)

--- a/dragonfly/room2d.py
+++ b/dragonfly/room2d.py
@@ -632,6 +632,9 @@ class Room2D(_BaseGeometry):
             if self._parent.is_top_floor:
                 hb_room[-1].boundary_condition = bcs.outdoors
 
+        # transfer any extension properties assigned to the Room2D
+        hb_room._properties = self.properties.to_honeybee(hb_room)
+
         return hb_room
 
     def to_dict(self, abridged=False, included_prop=None):

--- a/tests/building_test.py
+++ b/tests/building_test.py
@@ -257,6 +257,11 @@ def test_to_honeybee():
     assert len(hb_model.rooms[0][1].apertures) == 1
     assert len(hb_model.rooms[0][2].apertures) == 0
 
+    hb_model = building.to_honeybee(True, 0.01)
+    assert len(hb_model.rooms) == 2
+    for room in hb_model.rooms:
+        assert room.multiplier == 4
+
 
 def test_to_dict():
     """Test the Building to_dict method."""


### PR DESCRIPTION
This new code will ensure that ProgramTypes and ConstructionSets assigned to Dragonfly objects will be transferred to Honeybee objects.

Note that there isn't really a way to test this method within the dragonfly-core tests but the tests within the extensions will be using this code.