### PR TITLE
feat(windowparameter): Add classes to specify detailed windows

### DIFF
--- a/tests/room2d_test.py
+++ b/tests/room2d_test.py
@@ -137,6 +137,39 @@ def test_room2d_init_invalid():
         Room2D('Square Shoebox', Face3D(pts), 3, boundarycs, new_glz, shading)
 
 
+def test_room2d_init_clockwise():
+    """Test the initalization of Room2D objects with clockwise vertices."""
+    pts = (Point3D(0, 10, 3), Point3D(10, 10, 3), Point3D(10, 0, 3), Point3D(0, 0, 3))
+    ashrae_base = SimpleWindowRatio(0.4)
+    overhang = Overhang(1)
+    boundarycs = (bcs.outdoors, bcs.outdoors, bcs.ground, bcs.ground)
+    window = (ashrae_base, ashrae_base, None, None)
+    shading = (overhang, None, None, None)
+    room2d = Room2D('TestZone', Face3D(pts), 3, boundarycs, window, shading)
+
+    assert room2d.floor_geometry.boundary == tuple(reversed(pts))
+    assert room2d.boundary_conditions == tuple(reversed(boundarycs))
+    assert room2d.window_parameters == tuple(reversed(window))
+    assert room2d.shading_parameters == tuple(reversed(shading))
+
+    pts_hole = (Point3D(2, 8, 3), Point3D(8, 8, 3), Point3D(8, 2, 3), Point3D(2, 2, 3))
+    boundarycs = (bcs.outdoors, bcs.outdoors, bcs.ground, bcs.ground,
+                  bcs.outdoors, bcs.outdoors, bcs.ground, bcs.ground)
+    window = (ashrae_base, ashrae_base, None, None, ashrae_base, ashrae_base, None, None)
+    shading = (overhang, None, None, None, overhang, None, None, None)
+    room2d = Room2D('TestZone', Face3D(pts, holes=[pts_hole]), 3, boundarycs, window, shading)
+
+    assert room2d.floor_geometry.boundary == tuple(reversed(pts))
+    assert room2d.floor_geometry.holes[0] == pts_hole
+    assert room2d.boundary_conditions == \
+        (bcs.ground, bcs.ground, bcs.outdoors, bcs.outdoors,
+        bcs.outdoors, bcs.outdoors, bcs.ground, bcs.ground)
+    assert room2d.window_parameters == \
+        (None, None, ashrae_base, ashrae_base, ashrae_base, ashrae_base, None, None)
+    assert room2d.shading_parameters == \
+        (None, None, None, overhang, overhang, None, None, None)
+
+
 def test_room2d_init_from_polygon():
     """Test the initalization of Room2D objects from a Polygon2D."""
     pts = (Point2D(0, 0), Point2D(10, 0), Point2D(10, 10), Point2D(0, 10))
@@ -165,6 +198,25 @@ def test_room2d_init_from_polygon():
     assert room2d.floor_area == 100
     assert room2d.exterior_wall_area == 60
     assert room2d.exterior_aperture_area == 60 * 0.4
+
+
+def test_room2d_init_from_polygon_clockwise():
+    """Test the initalization of Room2D objects from a clockwise Polygon2D."""
+    pts_3d = (Point3D(0, 10, 3), Point3D(10, 10, 3), Point3D(10, 0, 3), Point3D(0, 0, 3))
+    pts = (Point2D(0, 10), Point2D(10, 10), Point2D(10, 0), Point2D(0, 0))
+    polygon = Polygon2D(pts)
+    ashrae_base = SimpleWindowRatio(0.4)
+    overhang = Overhang(1)
+    boundarycs = (bcs.outdoors, bcs.outdoors, bcs.ground, bcs.ground)
+    window = (ashrae_base, ashrae_base, None, None)
+    shading = (overhang, None, None, None)
+    room2d = Room2D.from_polygon('Square Shoebox', polygon, 3, 3,
+                                 boundarycs, window, shading)
+
+    assert room2d.floor_geometry.boundary == tuple(reversed(pts_3d))
+    assert room2d.boundary_conditions == tuple(reversed(boundarycs))
+    assert room2d.window_parameters == tuple(reversed(window))
+    assert room2d.shading_parameters == tuple(reversed(shading))
 
 
 def test_room2d_init_from_vertices():

--- a/tests/windowparameter_test.py
+++ b/tests/windowparameter_test.py
@@ -2,10 +2,12 @@
 import pytest
 
 from dragonfly.windowparameter import SingleWindow, SimpleWindowRatio, \
-    RepeatingWindowRatio
+    RepeatingWindowRatio, DetailedRectangularWindows, DetailedWindows
 
 from honeybee.face import Face
 
+from ladybug_geometry.geometry2d.pointvector import Point2D
+from ladybug_geometry.geometry2d.polygon import Polygon2D
 from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
 from ladybug_geometry.geometry3d.line import LineSegment3D
 from ladybug_geometry.geometry3d.face import Face3D
@@ -30,7 +32,9 @@ def test_single_window_equality():
     assert simple_window is simple_window
     assert simple_window is not simple_window_dup
     assert simple_window == simple_window_dup
+    assert hash(simple_window) == hash(simple_window_dup)
     assert simple_window != simple_window_alt
+    assert hash(simple_window) != hash(simple_window_alt)
 
 
 def test_single_window_dict_methods():
@@ -85,7 +89,9 @@ def test_simple_window_ratio_equality():
     assert ashrae_base is ashrae_base
     assert ashrae_base is not ashrae_base_dup
     assert ashrae_base == ashrae_base_dup
+    assert hash(ashrae_base) == hash(ashrae_base_dup)
     assert ashrae_base != ashrae_base_alt
+    assert hash(ashrae_base) != hash(ashrae_base_alt)
 
 
 def test_simple_window_ratio_dict_methods():
@@ -134,7 +140,9 @@ def test_repeating_window_ratio_equality():
     assert ashrae_base is ashrae_base
     assert ashrae_base is not ashrae_base_dup
     assert ashrae_base == ashrae_base_dup
+    assert hash(ashrae_base) == hash(ashrae_base_dup)
     assert ashrae_base != ashrae_base_alt
+    assert hash(ashrae_base) != hash(ashrae_base_alt)
 
 
 def test_repeating_window_scale():
@@ -171,3 +179,159 @@ def test_repeating_window_ratio_add_window_to_face():
     ap_area = sum([ap.area for ap in face.apertures])
     assert ashrae_base.area_from_segment(seg, height) == \
         pytest.approx(ap_area, rel=1e-3) == width * height * 0.4
+
+
+def test_detailed_rectangular_init():
+    """Test the initalization of DetailedRectangularWindows and basic properties."""
+    origins = (Point2D(2, 1), Point2D(5, 0.5))
+    widths = (1, 3)
+    heights = (1, 2)
+    detailed_window = DetailedRectangularWindows(origins, widths, heights)
+    str(detailed_window)  # test the string representation
+
+    assert detailed_window.origins == origins
+    assert detailed_window.widths == widths
+    assert detailed_window.heights == heights
+
+
+def test_detailed_rectangular_equality():
+    """Test the equality of DetailedRectangularWindows."""
+    origins = (Point2D(2, 1), Point2D(5, 0.5))
+    widths = (1, 3)
+    heights = (1, 2)
+    heights_alt = (1, 1)
+    detailed_window = DetailedRectangularWindows(origins, widths, heights)
+    detailed_window_dup = detailed_window.duplicate()
+    detailed_window_alt = DetailedRectangularWindows(origins, widths, heights_alt)
+
+    assert detailed_window is detailed_window
+    assert detailed_window is not detailed_window_dup
+    assert detailed_window == detailed_window_dup
+    assert hash(detailed_window) == hash(detailed_window_dup)
+    assert detailed_window != detailed_window_alt
+    assert hash(detailed_window) != hash(detailed_window_alt)
+
+
+def test_detailed_rectangular_dict_methods():
+    """Test the to/from dict methods."""
+    origins = (Point2D(2, 1), Point2D(5, 0.5))
+    widths = (1, 3)
+    heights = (1, 2)
+    detailed_window = DetailedRectangularWindows(origins, widths, heights)
+
+    glz_dict = detailed_window.to_dict()
+    new_detailed_window = DetailedRectangularWindows.from_dict(glz_dict)
+    assert new_detailed_window == detailed_window
+    assert glz_dict == new_detailed_window.to_dict()
+
+
+def test_detailed_rectangular_scale():
+    """Test the scale method."""
+    origins = (Point2D(2, 1), Point2D(5, 0.5))
+    widths = (1, 3)
+    heights = (1, 2)
+    detailed_window = DetailedRectangularWindows(origins, widths, heights)
+
+    new_detailed_window  = detailed_window.scale(2)
+    assert new_detailed_window.origins == (Point2D(4, 2), Point2D(10, 1))
+    assert new_detailed_window.widths == (2, 6)
+    assert new_detailed_window.heights == (2, 4)
+
+
+def test_detailed_rectangular_flip():
+    """Test the flip method."""
+    origins = (Point2D(2, 1), Point2D(5, 0.5))
+    widths = (1, 3)
+    heights = (1, 2)
+    detailed_window = DetailedRectangularWindows(origins, widths, heights)
+
+    new_detailed_window  = detailed_window.flip(10)
+    assert new_detailed_window.origins == (Point2D(7, 1), Point2D(2, 0.5))
+    assert new_detailed_window.widths == widths
+    assert new_detailed_window.heights == heights
+
+
+def test_single_window_add_window_to_face():
+    """Test the add_window_to_face method."""
+    origins = (Point2D(2, 1), Point2D(5, 0.5))
+    widths = (1, 3)
+    heights = (1, 2)
+    detailed_window = DetailedRectangularWindows(origins, widths, heights)
+    height = 3
+    width = 10
+    seg = LineSegment3D.from_end_points(Point3D(0, 0, 2), Point3D(width, 0, 2))
+    face = Face('test face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
+    detailed_window.add_window_to_face(face, 0.01)
+
+    assert len(face.apertures) == 2
+    assert len(face.apertures[0].vertices) == 4
+    assert len(face.apertures[1].vertices) == 4
+    assert face.apertures[0].area == widths[0] * heights[0]
+    assert face.apertures[1].area == widths[1] * heights[1]
+
+
+def test_detailed_init():
+    """Test the initalization of DetailedWindows and basic properties."""
+    pts_1 = (Point2D(2, 1), Point2D(3, 1), Point2D(3, 2), Point2D(2, 2))
+    pts_2 = (Point2D(5, 0.5), Point2D(8, 0.5), Point2D(8, 2.5), Point2D(5, 2.5))
+    detailed_window = DetailedWindows((Polygon2D(pts_1), Polygon2D(pts_2)))
+    str(detailed_window)  # test the string representation
+
+    assert detailed_window.polygons[0].vertices == pts_1
+    assert detailed_window.polygons[1].vertices == pts_2
+
+
+def test_detailed_equality():
+    """Test the equality of DetailedWindows."""
+    pts_1 = (Point2D(2, 1), Point2D(3, 1), Point2D(3, 2), Point2D(2, 2))
+    pts_2 = (Point2D(5, 0.5), Point2D(8, 0.5), Point2D(8, 2.5), Point2D(5, 2.5))
+    pts_3 = (Point2D(5, 0.4), Point2D(8, 0.5), Point2D(8, 2.5), Point2D(5, 2.5))
+    detailed_window = DetailedWindows((Polygon2D(pts_1), Polygon2D(pts_2)))
+    detailed_window_dup = detailed_window.duplicate()
+    detailed_window_alt = DetailedWindows((Polygon2D(pts_1), Polygon2D(pts_3)))
+
+    assert detailed_window is detailed_window
+    assert detailed_window is not detailed_window_dup
+    assert detailed_window == detailed_window_dup
+    assert hash(detailed_window) == hash(detailed_window_dup)
+    assert detailed_window != detailed_window_alt
+    assert hash(detailed_window) != hash(detailed_window_alt)
+
+
+def test_detailed_dict_methods():
+    """Test the to/from dict methods."""
+    pts_1 = (Point2D(2, 1), Point2D(3, 1), Point2D(3, 2), Point2D(2, 2))
+    pts_2 = (Point2D(5, 0.5), Point2D(8, 0.5), Point2D(8, 2.5), Point2D(5, 2.5))
+    detailed_window = DetailedWindows((Polygon2D(pts_1), Polygon2D(pts_2)))
+
+    glz_dict = detailed_window.to_dict()
+    new_detailed_window = DetailedWindows.from_dict(glz_dict)
+    assert new_detailed_window == detailed_window
+    assert glz_dict == new_detailed_window.to_dict()
+
+
+def test_detailed_scale():
+    """Test the scale method."""
+    pts_1 = (Point2D(2, 1), Point2D(3, 1), Point2D(3, 2), Point2D(2, 2))
+    pts_2 = (Point2D(5, 0.5), Point2D(8, 0.5), Point2D(8, 2.5), Point2D(5, 2.5))
+    detailed_window = DetailedWindows((Polygon2D(pts_1), Polygon2D(pts_2)))
+
+    new_detailed_window  = detailed_window.scale(2)
+    assert new_detailed_window.polygons[0].vertices == \
+        (Point2D(4, 2), Point2D(6, 2), Point2D(6, 4), Point2D(4, 4))
+    assert new_detailed_window.polygons[1].vertices == \
+        (Point2D(10, 1), Point2D(16, 1), Point2D(16, 5), Point2D(10, 5))
+
+
+def test_detailed_flip():
+    """Test the flip method."""
+    pts_1 = (Point2D(2, 1), Point2D(3, 1), Point2D(3, 2), Point2D(2, 2))
+    pts_2 = (Point2D(5, 0.5), Point2D(8, 0.5), Point2D(8, 2.5), Point2D(5, 2.5))
+    detailed_window = DetailedWindows((Polygon2D(pts_1), Polygon2D(pts_2)))
+
+    new_detailed_window  = detailed_window.flip(10)
+    assert new_detailed_window.polygons[0].vertices == \
+        tuple(reversed((Point2D(8, 1), Point2D(7, 1), Point2D(7, 2), Point2D(8, 2))))
+    assert new_detailed_window.polygons[1].vertices == \
+        tuple(reversed((Point2D(5, 0.5), Point2D(2, 0.5), Point2D(2, 2.5), Point2D(5, 2.5))))
+


### PR DESCRIPTION
This commit adds two new classes to the windowparameter module:

One that accepts window widths/heights along with an origin 2D point for each window within the plane of the wall. this one can be easily editable in schema form (just change width and height).  This includes checks to not generate windows if they are outside the boundary of the wall, meaning that someone can create a pattern of rectangular windows and then apply it to as many walls as they want.

One that accepts a list of 2D vertices within the plane of the wall. This one doesn't have the same checks but it allows for detailed specification of window faces.