### PR TITLE
Format docstrings for correct display in sphinx-generated bootstrap pages

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,40 @@
+/*
+ * bootstrap-sphinx.css
+ * ~~~~~~~~~~~~~~~~~~~~
+ *
+ * Sphinx stylesheet -- Bootstrap theme.
+ */
+
+
+/* The code below is based on the bootstrap website sidebar */
+
+
+/* Show and affix the side nav when space allows it */
+@media screen and (min-width: 992px) {
+  .bs-sidenav .nav > .active > ul {
+    display: block;
+  }
+  /* Widen the fixed sidenav */
+  .bs-sidenav.affix,
+  .bs-sidenav.affix-bottom {
+    width: 292px;
+  }
+  .bs-sidenav.affix {
+    position: fixed; /* Undo the static from mobile first approach */
+  }
+  .bs-sidenav.affix-bottom {
+    position: absolute; /* Undo the static from mobile first approach */
+  }
+  .bs-sidenav.affix-bottom .bs-sidenav,
+  .bs-sidenav.affix .bs-sidenav {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+@media screen and (min-width: 1200px) {
+  /* Widen the fixed sidenav again */
+  .bs-sidenav.affix-bottom,
+  .bs-sidenav.affix {
+    width: 360px;
+  }
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,107 @@
+{% extends "basic/layout.html" %}
+
+{% if theme_bootstrap_version == "3" %}
+  {% set bootstrap_version, navbar_version = "3.3.7", "" %}
+  {% set bs_span_prefix = "col-md-" %}
+{% else %}
+  {% set bootstrap_version, navbar_version = "2.3.2", "-2" %}
+  {% set bs_span_prefix = "span" %}
+{% endif %}
+
+{%- set render_sidebar = (not embedded) and (not theme_nosidebar|tobool) and sidebars %}
+
+{%- set bs_content_width = render_sidebar and "8" or "12"%}
+
+{%- block doctype -%}
+<!DOCTYPE html>
+{%- endblock %}
+
+{# Sidebar: Rework into our Bootstrap nav section. #}
+{% macro navBar() %}
+{% include "navbar" + navbar_version + ".html" %}
+{% endmacro %}
+
+{% if theme_bootstrap_version == "3" %}
+  {%- macro bsidebar() %}
+      {%- if render_sidebar %}
+      <div class="{{ bs_span_prefix }}4">
+        <div id="sidebar" class="bs-sidenav" role="complementary">
+          {%- for sidebartemplate in sidebars %}
+            {%- include sidebartemplate %}
+          {%- endfor %}
+        </div>
+      </div>
+      {%- endif %}
+  {%- endmacro %}
+{% else %}
+  {%- macro bsidebar() %}
+      {%- if render_sidebar %}
+      <div class="{{ bs_span_prefix }}4">
+        <div id="sidebar" class="bs-sidenav well" data-spy="affix">
+          {%- for sidebartemplate in sidebars %}
+            {%- include sidebartemplate %}
+          {%- endfor %}
+        </div>
+      </div>
+      {%- endif %}
+  {%- endmacro %}
+{% endif %}
+
+{%- block extrahead %}
+<meta charset='utf-8'>
+<meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'>
+<meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1'>
+<meta name="apple-mobile-web-app-capable" content="yes">
+<script type="text/javascript" src="{{ pathto('_static/js/jquery-1.11.0.min.js', 1) }} "></script>
+<script type="text/javascript" src="{{ pathto('_static/js/jquery-fix.js', 1) }} "></script>
+<script type="text/javascript" src="{{ pathto('_static', 1) + '/bootstrap-' + bootstrap_version + '/js/bootstrap.min.js' }} "></script>
+<script type="text/javascript" src="{{ pathto('_static/bootstrap-sphinx.js', 1) }} "></script>
+{% endblock %}
+
+{# Silence the sidebar's, relbar's #}
+{% block header %}{% endblock %}
+{% block relbar1 %}{% endblock %}
+{% block relbar2 %}{% endblock %}
+{% block sidebarsourcelink %}{% endblock %}
+
+{%- block content %}
+{{ navBar() }}
+<div class="container">
+  <div class="row">
+    {%- block sidebar1 %}{{ bsidebar() }}{% endblock %}
+    <div class="body {{ bs_span_prefix }}{{ bs_content_width }} content" role="main">
+      {% block body %}{% endblock %}
+    </div>
+    {% block sidebar2 %} {# possible location for sidebar #} {% endblock %}
+  </div>
+</div>
+{%- endblock %}
+
+{%- block footer %}
+<footer class="footer">
+  <div class="container">
+    <p class="pull-right">
+      <a href="#">Back to top</a>
+      {% if theme_source_link_position == "footer" %}
+        <br/>
+        {% include "sourcelink.html" %}
+      {% endif %}
+    </p>
+    <p>
+    {%- if show_copyright %}
+      {%- if hasdoc('copyright') %}
+        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}<br/>
+      {%- else %}
+        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}<br/>
+      {%- endif %}
+    {%- endif %}
+    {%- if last_updated %}
+      {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}<br/>
+    {%- endif %}
+    {%- if show_sphinx %}
+      {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}<br/>
+    {%- endif %}
+    </p>
+  </div>
+</footer>
+{%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,8 +48,8 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
-	'sphinxcontrib.fulltoc',
-	'sphinx.ext.napoleon',
+    'sphinxcontrib.fulltoc',
+    'sphinx.ext.napoleon',
     'sphinx_click.ext'
 ]
 
@@ -102,11 +102,17 @@ html_theme_options = {
     # Fix navigation bar to top of page?
     # Values: "true" (default) or "false"
     'navbar_fixed_top': "true",
-	'navbar_pagenav': True,
+    'navbar_pagenav': True,
     'source_link_position': "nav",
-	'bootswatch_theme': "united",
+    'bootswatch_theme': "united",
     'bootstrap_version': "3",
-	}
+}
+
+# Bootstrap theme custom file paths (relative to this file)
+# Layout.html path (already added above, include if different)
+# templates_path = ['_templates']
+# Stylesheet path
+html_static_path = ["_static"]
 
 # on_rtd is whether we are on readthedocs.org
 # on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -218,3 +224,20 @@ epub_exclude_files = ['search.html']
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# -- Options for autodoc extension --------------------------------------------
+autodoc_default_options = {
+    'inherited-members': True,
+}
+
+autodoc_member_order = 'groupwise'
+
+
+def setup(app):
+    """Run custom code with access to the Sphinx application object
+    Args:
+        app: the Sphinx application object
+    """
+
+    # Add bootstrap theme custom stylesheet
+    app.add_stylesheet("custom.css")

--- a/dragonfly/_base.py
+++ b/dragonfly/_base.py
@@ -8,18 +8,17 @@ from ladybug_geometry.geometry2d.pointvector import Point2D
 class _BaseGeometry(object):
     """A base class for all geometry objects.
 
+    Args:
+        name: Object name. Must be < 100 characters.
+
     Properties:
-        name
-        display_name
+        * name
+        * display_name
     """
     __slots__ = ('_name', '_display_name', '_properties')
 
     def __init__(self, name):
-        """Initialize base object.
-
-        Args:
-            name: Object name. Must be < 100 characters.
-        """
+        """Initialize base object."""
         self.name = name
         self._properties = None
 
@@ -52,11 +51,11 @@ class _BaseGeometry(object):
     def duplicate(self):
         """Get a copy of this object."""
         return self.__copy__()
-    
+
     @staticmethod
     def _calculate_min(geometry_objects):
         """Calculate min Point2D around an array of geometry with min attributes.
-        
+
         This is used in all functions that calculate bounding rectangles around
         dragonfly objects and assess when two objects are in close proximity.
         """
@@ -73,7 +72,7 @@ class _BaseGeometry(object):
     @staticmethod
     def _calculate_max(geometry_objects):
         """Calculate max Point2D around an array of geometry with max attributes.
-        
+
         This is used in all functions that calculate bounding rectangles around
         dragonfly objects and assess when two objects are in close proximity.
         """

--- a/dragonfly/building.py
+++ b/dragonfly/building.py
@@ -22,6 +22,16 @@ except ImportError:
 class Building(_BaseGeometry):
     """A complete Building defined by Stories.
 
+    Args:
+        name: Building name. Must be < 100 characters.
+        unique_stories: An array of unique Dragonfly Story objects that
+            together form the entire building. Stories should be ordered
+            from lowest floor to highest floor and they will be automatically
+            sorted besed on floor height when they are added to a Building.
+            Note that, if a given Story is repeated several times over the
+            height of the Building, the unique Story included in this list
+            should be the first (lowest) Story of the repeated floors.
+
     Properties:
         * name
         * display_name
@@ -39,18 +49,7 @@ class Building(_BaseGeometry):
     __slots__ = ('_unique_stories',)
 
     def __init__(self, name, unique_stories):
-        """A complete Building defined by Stories.
-
-        Args:
-            name: Building name. Must be < 100 characters.
-            unique_stories: An array of unique Dragonfly Story objects that
-                together form the entire building. Stories should be ordered
-                from lowest floor to highest floor and they will be automatically
-                sorted besed on floor height when they are added to a Building.
-                Note that, if a given Story is repeated several times over the
-                height of the Building, the unique Story included in this list
-                should be the first (lowest) Story of the repeated floors.
-        """
+        """A complete Building defined by Stories."""
         _BaseGeometry.__init__(self, name)  # process the name
 
         # process the story geometry
@@ -260,20 +259,20 @@ class Building(_BaseGeometry):
         """
         return sum([story.exterior_aperture_area * story.multiplier
                     for story in self._unique_stories])
-    
+
     @property
     def min(self):
         """Get a Point2D for the min bounding rectangle vertex in the XY plane.
-        
+
         This is useful in calculations to determine if this Building is in proximity
         to other objects.
         """
         return self._calculate_min(self._unique_stories)
-    
+
     @property
     def max(self):
         """Get a Point2D for the max bounding rectangle vertex in the XY plane.
-        
+
         This is useful in calculations to determine if this Building is in proximity
         to other objects.
         """
@@ -332,7 +331,7 @@ class Building(_BaseGeometry):
 
     def add_prefix(self, prefix):
         """Change the name of this object and all child objects by inserting a prefix.
-        
+
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object
         into one Model (like making a model of repeating buildings) since all objects
@@ -370,7 +369,7 @@ class Building(_BaseGeometry):
             new_ground_floor = (self._separated_ground_floor(story),)
             story.multiplier = story.multiplier - 1
             story.move(Vector3D(0, 0, story.floor_to_floor_height))  # 2nd floor
-        
+
         # ensure that the top floor is unique
         if self._unique_stories[-1].multiplier != 1:
             new_top_floor = (self._separated_top_floor(story),)
@@ -474,11 +473,11 @@ class Building(_BaseGeometry):
                                   for s in self._unique_stories]
         base['properties'] = self.properties.to_dict(abridged, included_prop)
         return base
-    
+
     @staticmethod
     def buildings_to_honeybee(buildings, use_multiplier, tolerance=0.01):
         """Convert an array of Building objects into a single honeybee Model.
-        
+
         Args:
             buildings: An array of Building objects to be converted into a
                 honeybee Model.
@@ -498,7 +497,7 @@ class Building(_BaseGeometry):
         for bldg in buildings[1:]:
             base_model.add_model(bldg.to_honeybee(use_multiplier, tolerance))
         return base_model
-    
+
     @staticmethod
     def buildings_to_honeybee_self_shade(
             buildings, context_shades=None, shade_distance=None, use_multiplier=True,
@@ -509,7 +508,7 @@ class Building(_BaseGeometry):
         the other input Buildings will appear as context shade geometry. Thus,
         each Model is its own simulate-able unit accounting for the total
         self-shading of the input Buildings.
-        
+
         Args:
             buildings: An array of Building objects to be converted into honeybee
                 Models that account for their own shading of one another.
@@ -552,12 +551,12 @@ class Building(_BaseGeometry):
                     c_min, c_max = con.min, con.max
                     center = Point2D((c_min.x + c_max.x) / 2, (c_min.y + c_max.y) / 2)
                     con_pts.append((c_min, center, c_max))
-        
+
         # loop through each Building and create a model
         num_bldg = len(buildings)
         for i, bldg in enumerate(buildings):
             model = bldg.to_honeybee(use_multiplier, tolerance)
-            
+
             if shade_distance is None:  # add all other bldg shades to the model
                 for j in xrange(i + 1, num_bldg):  # buildings before this one
                     for shd in bldg_shades[j]:
@@ -628,7 +627,7 @@ class Building(_BaseGeometry):
             return False
 
         return True
-    
+
     @staticmethod
     def _bound_rect_in_dist(bound_pts1, bound_pts2, distance):
         """Check if the bounding rectangles of two footprints overlap within a distance.

--- a/dragonfly/context.py
+++ b/dragonfly/context.py
@@ -13,6 +13,11 @@ import math
 class ContextShade(_BaseGeometry):
     """A Context Shade object defined by an array of Face3Ds (eg. canopy, trees, etc.).
 
+    Args:
+        name: ContextShade name. Must be < 100 characters.
+        geometry: An array of ladybug_geometry Face3D objects that together
+            represent the context shade.
+
     Properties:
         * name
         * display_name
@@ -24,13 +29,7 @@ class ContextShade(_BaseGeometry):
     __slots__ = ('_geometry',)
 
     def __init__(self, name, geometry):
-        """A Context Shade object defined by an array of Face3Ds.
-
-        Args:
-            name: ContextShade name. Must be < 100 characters.
-            geometry: An array of ladybug_geometry Face3D objects that together
-                represent the context shade.
-        """
+        """A Context Shade object defined by an array of Face3Ds."""
         _BaseGeometry.__init__(self, name)  # process the name
 
         # process the geometry
@@ -63,30 +62,30 @@ class ContextShade(_BaseGeometry):
         if data['properties']['type'] == 'ContextShadeProperties':
             shade.properties._load_extension_attr_from_dict(data['properties'])
         return shade
-    
+
     @property
     def geometry(self):
         """Get a tuple of Face3D objects that together represent the context shade."""
         return self._geometry
-    
+
     @property
     def area(self):
         """Get a number for the total surface area of the ContextShade."""
         return sum([geo.area for geo in self._geometry])
-    
+
     @property
     def min(self):
         """Get a Point2D for the min bounding rectangle vertex in the XY plane.
-        
+
         This is useful in calculations to determine if this ContextShade is in
         proximity to other objects.
         """
         return self._calculate_min(self._geometry)
-    
+
     @property
     def max(self):
         """Get a Point2D for the max bounding rectangle vertex in the XY plane.
-        
+
         This is useful in calculations to determine if this ContextShade is in
         proximity to other objects.
         """
@@ -94,7 +93,7 @@ class ContextShade(_BaseGeometry):
 
     def add_prefix(self, prefix):
         """Change the name of this object by inserting a prefix.
-        
+
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object
         into one Model (like making a model of repeated shades) since all objects
@@ -107,7 +106,7 @@ class ContextShade(_BaseGeometry):
         """
         self.name = '{}_{}'.format(prefix, self.display_name)
         self.properties.add_prefix(prefix)
-    
+
     def move(self, moving_vec):
         """Move this ContextShade along a vector.
 

--- a/dragonfly/extensionutil.py
+++ b/dragonfly/extensionutil.py
@@ -15,13 +15,18 @@ def model_extension_dicts(data, extension_key, building_ext_dicts=[], story_ext_
         extension_key: Text for the key of the extension (eg. "energy", "radiance").
 
     Returns:
-        building_ext_dicts: A list of Building extension property dictionaries that
+        A tuple with four elements
+
+        -   building_ext_dicts: A list of Building extension property dictionaries that
             align with the serialized model.buildings.
-        story_ext_dicts: A list of Story extension property dictionaries that
+
+        -   story_ext_dicts: A list of Story extension property dictionaries that
             align with the serialized model.stories.
-        room2d_ext_dicts: A list of Room2D extension property dictionaries that
+
+        -   room2d_ext_dicts: A list of Room2D extension property dictionaries that
             align with the serialized model.rooms.
-        context_shade_ext_dicts: A list of ContextShade extension property dictionaries
+
+        -   context_shade_ext_dicts: A list of ContextShade extension property dictionaries
             that align with the serialized model.context_shades.
     """
     assert data['type'] == 'Model', \
@@ -48,9 +53,13 @@ def building_extension_dicts(building_list, extension_key, building_ext_dicts=[]
         extension_key: Text for the key of the extension (eg. "energy", "radiance").
 
     Returns:
-        building_ext_dicts: A list with the Building extension property dictionaries.
-        story_ext_dicts: A list with Story extension property dictionaries.
-        room2d_ext_dicts: A list with Room2D extension property dictionaries.
+        A tuple with three elements
+
+        -   building_ext_dicts: A list with the Building extension property dictionaries.
+
+        -   story_ext_dicts: A list with Story extension property dictionaries.
+
+        -   room2d_ext_dicts: A list with Room2D extension property dictionaries.
     """
     for bldg_dict in building_list:
         building_ext_dicts.append(bldg_dict['properties'][extension_key])
@@ -68,8 +77,11 @@ def story_extension_dicts(story_list, extension_key, story_ext_dicts=[],
         extension_key: Text for the key of the extension (eg. "energy", "radiance").
 
     Returns:
-        story_ext_dicts: A list with Story extension property dictionaries.
-        room2d_ext_dicts: A list with Room2D extension property dictionaries.
+        A tuple with two elements
+
+        -   story_ext_dicts: A list with Story extension property dictionaries.
+
+        -   room2d_ext_dicts: A list with Room2D extension property dictionaries.
     """
     for story_dict in story_list:
         story_ext_dicts.append(story_dict['properties'][extension_key])
@@ -86,7 +98,7 @@ def room2d_extension_dicts(room2d_list, extension_key, room2d_ext_dicts=[]):
         extension_key: Text for the key of the extension (eg. "energy", "radiance").
 
     Returns:
-        room2d_ext_dicts: A list with Room2D extension property dictionaries.
+        room2d_ext_dict -- A list with Room2D extension property dictionaries.
     """
     for room_dict in room2d_list:
         room2d_ext_dicts.append(room_dict['properties'][extension_key])
@@ -102,8 +114,8 @@ def context_shade_extension_dicts(context_shade_list, extension_key,
         extension_key: Text for the key of the extension (eg. "energy", "radiance").
 
     Returns:
-        context_shade_ext_dicts: A list with ContextShade extension property
-            dictionaries.
+        context_shade_ext_dicts -- A list with ContextShade extension property
+        dictionaries.
     """
     for shd_dict in context_shade_list:
         context_shade_ext_dicts.append(shd_dict['properties'][extension_key])

--- a/dragonfly/model.py
+++ b/dragonfly/model.py
@@ -19,6 +19,30 @@ import math
 class Model(_BaseGeometry):
     """A collection of Buildings and ContextShades for an entire model.
 
+    Args:
+        name: Model name. Must be < 100 characters.
+        buildings: A list of Building objects in the model.
+        context_shades: A list of ContextShade objects in the model.
+        north_angle: An number between 0 and 360 to set the clockwise north
+            direction in degrees. Default is 0.
+        units: Text for the units system in which the model geometry
+            exists. Default: 'Meters'. Choose from the following:
+
+            * Meters
+            * Millimeters
+            * Feet
+            * Inches
+            * Centimeters
+
+        tolerance: The maximum difference between x, y, and z values at which
+            vertices are considered equivalent. Zero indicates that no tolerance
+            checks should be performed and certain capabilities like to_honeybee
+            will not be available. Default: 0.
+        angle_tolerance: The max angle difference in degrees that vertices are
+            allowed to differ from one another in order to consider them colinear.
+            Zero indicates that no angle tolerance checks should be performed.
+            Default: 0.
+
     Properties:
         * name
         * display_name
@@ -36,35 +60,12 @@ class Model(_BaseGeometry):
     """
     __slots__ = ('_buildings', '_context_shades', '_north_angle', '_north_vector',
                  '_units', '_tolerance', '_angle_tolerance')
-    
+
     UNITS = hb_model.UNITS
 
     def __init__(self, name, buildings=None, context_shades=None, north_angle=0,
                  units='Meters', tolerance=0, angle_tolerance=0):
-        """A collection of Buildings and ContextShades for an entire model.
-
-        Args:
-            name: Model name. Must be < 100 characters.
-            buildings: A list of Building objects in the model.
-            context_shades: A list of ContextShade objects in the model.
-            north_angle: An number between 0 and 360 to set the clockwise north
-                direction in degrees. Default is 0.
-            units: Text for the units system in which the model geometry
-                exists. Default: 'Meters'. Choose from the following:
-                    * Meters
-                    * Millimeters
-                    * Feet
-                    * Inches
-                    * Centimeters
-            tolerance: The maximum difference between x, y, and z values at which
-                vertices are considered equivalent. Zero indicates that no tolerance
-                checks should be performed and certain capabilities like to_honeybee
-                will not be available. Default: 0.
-            angle_tolerance: The max angle difference in degrees that vertices are
-                allowed to differ from one another in order to consider them colinear.
-                Zero indicates that no angle tolerance checks should be performed.
-                Default: 0.
-        """
+        """A collection of Buildings and ContextShades for an entire model."""
         self.name = name
         self.north_angle = north_angle
         self.units = units
@@ -119,7 +120,7 @@ class Model(_BaseGeometry):
         # assign extension properties to the model
         model.properties.apply_properties_from_dict(data)
         return model
-    
+
     @property
     def north_angle(self):
         """Get or set a number between 0 and 360 for the north direction in degrees."""
@@ -157,7 +158,7 @@ class Model(_BaseGeometry):
     @property
     def tolerance(self):
         """Get or set a number for the max meaningful difference between x, y, z values.
-        
+
         This value should be in the Model's units. Zero indicates cases where
         no tolerance checks should be performed.
         """
@@ -170,7 +171,7 @@ class Model(_BaseGeometry):
     @property
     def angle_tolerance(self):
         """Get or set a number for the max meaningful angle difference in degrees.
-        
+
         Face3D normal vectors differing by this amount are not considered parallel
         and Face3D segments that differ from 180 by this amount are not considered
         colinear. Zero indicates cases where no angle_tolerance checks should be
@@ -191,7 +192,7 @@ class Model(_BaseGeometry):
     def context_shades(self):
         """Get a tuple of all ContextShade objects in the model."""
         return tuple(self._context_shades)
-    
+
     @property
     def stories(self):
         """Get a tuple of all unique Story objects in the model."""
@@ -208,16 +209,16 @@ class Model(_BaseGeometry):
     @property
     def min(self):
         """Get a Point2D for the min bounding rectangle vertex in the XY plane.
-        
+
         This is useful in calculations to determine if this Model is in proximity
         to other objects.
         """
         return self._calculate_min(self._buildings + self._context_shades)
-    
+
     @property
     def max(self):
         """Get a Point2D for the max bounding rectangle vertex in the XY plane.
-        
+
         This is useful in calculations to determine if this Model is in proximity
         to other objects.
         """
@@ -327,11 +328,12 @@ class Model(_BaseGeometry):
         Args:
             units: Text for the units to which the Model geometry should be
                 converted. Default: Meters. Choose from the following:
-                    * Meters
-                    * Millimeters
-                    * Feet
-                    * Inches
-                    * Centimeters
+
+                * Meters
+                * Millimeters
+                * Feet
+                * Inches
+                * Centimeters
         """
         if self.units != units:
             scale_fac1 = hb_model.conversion_factor_to_meters(self.units)
@@ -385,7 +387,7 @@ class Model(_BaseGeometry):
                                  'the Model:\n{}'.format('\n'.join(bldg_names)))
             return False
         return True
-    
+
     def to_honeybee(self, object_per_model='Building', shade_distance=None,
                     use_multiplier=True, tolerance=None):
         """Convert Dragonfly Mdel to an array of Honeybee Models.
@@ -394,14 +396,16 @@ class Model(_BaseGeometry):
             object_per_model: Text to describe how the input Buildings should be
                 divided across the output Models. Default: 'Building'. Choose from
                 the following options:
-                    * District - All buildings will be added to a single Honeybee Model.
-                        Such a Model can take a long time to simulate so this is only
-                        recommended for small numbers of buildings or cases where
-                        exchange of data between Buildings is necessary.
-                    * Building - Each input building will be exported into its own Model.
-                        For each Model, the other buildings input to this component will
-                        appear as context shade geometry. Thus, each Model is its own
-                        simulate-able unit.
+
+                * District - All buildings will be added to a single Honeybee Model.
+                  Such a Model can take a long time to simulate so this is only
+                  recommended for small numbers of buildings or cases where
+                  exchange of data between Buildings is necessary.
+                * Building - Each input building will be exported into its own Model.
+                  For each Model, the other buildings input to this component will
+                  appear as context shade geometry. Thus, each Model is its own
+                  simulate-able unit.
+
             shade_distance: An optional number to note the distance beyond which other
                 objects' shade should not be exported into a given Model. This is
                 helpful for reducing the simulation run time of each Model when other
@@ -444,12 +448,12 @@ class Model(_BaseGeometry):
         else:
             raise ValueError('Unrecognized object_per_model input: '
                             '{}'.format(object_per_model))
-        
+
         # change the north if the one on this model is not the default
         if self._north_angle != 0 and self._north_angle != 360:
             for model in models:
                 model.north_angle = self._north_angle
-        
+
         # change the tolerance and untis systems to match the dragonfly model
         for model in models:
             model.units = self.units
@@ -459,7 +463,7 @@ class Model(_BaseGeometry):
         # transfer Model extension attributes to the honeybee models
         for hb_model in models:
             hb_model._properties = self.properties.to_honeybee(hb_model)
-        
+
         return models
 
     def to_dict(self, included_prop=None):

--- a/dragonfly/properties.py
+++ b/dragonfly/properties.py
@@ -9,16 +9,20 @@ import honeybee.properties as hb_properties
 
 
 class _Properties(object):
-    """Base class for all Properties classes."""
+    """Base class for all Properties classes.
+
+    Args:
+        host: A dragonfly-core geometry object that hosts these properties
+            (ie. Building, Story, Room2D).
+
+    Properties:
+        * host
+
+    """
     _do_not_duplicate = ('host', 'to_dict', 'to_honeybee', 'ToString')
 
     def __init__(self, host):
-        """Initialize properties.
-
-        Args:
-            host: A dragonfly-core geometry object that hosts these properties
-                (ie. Building, Story, Room2D).
-        """
+        """Initialize properties."""
         self._host = host
 
     @property
@@ -55,11 +59,11 @@ class _Properties(object):
 
     def _add_prefix_extension_attr(self, prefix):
         """Change the name extension attributes unique to this object by adding a prefix.
-        
+
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object
         into one Model (like making a model of repeated buildings).
-        
+
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the object and does not add the prefix to attributes that are
         shared across several objects.
@@ -190,6 +194,9 @@ class ModelProperties(_Properties):
     """Dragonfly Model Properties. This class will be extended by extensions.
 
     Usage:
+
+    .. code-block:: python
+
         model = Model('South Boston District', list_of_buildings)
         model.properties -> ModelProperties
         model.properties.radiance -> ModelRadianceProperties
@@ -265,6 +272,9 @@ class ContextShadeProperties(_Properties):
     """Dragonfly ContextShade properties. This class will be extended by extensions.
 
     Usage:
+
+    .. code-block:: python
+
         canopy = ContextShade('Outdoor Canopy', canopy_geo)
         canopy.properties -> ContextShadeProperties
         canopy.properties.radiance -> ContextShadeRadianceProperties
@@ -298,7 +308,7 @@ class ContextShadeProperties(_Properties):
 
     def add_prefix(self, prefix):
         """Change the name extension attributes unique to this object by adding a prefix.
-        
+
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the ContextShade and does not add the prefix to attributes that are
         shared across several ContextShades.
@@ -317,6 +327,9 @@ class BuildingProperties(_Properties):
     """Dragonfly Building properties. This class will be extended by extensions.
 
     Usage:
+
+    .. code-block:: python
+
         building = Building('Office Tower', unique_stories)
         building.properties -> BuildingProperties
         building.properties.radiance -> BuildingRadianceProperties
@@ -341,7 +354,7 @@ class BuildingProperties(_Properties):
 
     def add_prefix(self, prefix):
         """Change the name extension attributes unique to this object by adding a prefix.
-        
+
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the Building and does not add the prefix to attributes that are
         shared across several Buildings.
@@ -360,6 +373,9 @@ class StoryProperties(_Properties):
     """Dragonfly Story properties. This class will be extended by extensions.
 
     Usage:
+
+    .. code-block:: python
+
         story = Story('Ground Floor Retail', room_2ds)
         story.properties -> StoryProperties
         story.properties.radiance -> StoryRadianceProperties
@@ -384,7 +400,7 @@ class StoryProperties(_Properties):
 
     def add_prefix(self, prefix):
         """Change the name extension attributes unique to this object by adding a prefix.
-        
+
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the Story and does not add the prefix to attributes that are
         shared across several Stories.
@@ -403,6 +419,9 @@ class Room2DProperties(_Properties):
     """Dragonfly Room2D properties. This class will be extended by extensions.
 
     Usage:
+
+    .. code-block:: python
+
         room = Room2D('Office', geometry)
         room.properties -> Room2DProperties
         room.properties.radiance -> Room2DRadianceProperties
@@ -436,7 +455,7 @@ class Room2DProperties(_Properties):
 
     def add_prefix(self, prefix):
         """Change the name extension attributes unique to this object by adding a prefix.
-        
+
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the Room2D (eg. single-room HVAC systems) and does not add
         the prefix to attributes that are shared across several Rooms2Ds (eg.

--- a/dragonfly/shadingparameter.py
+++ b/dragonfly/shadingparameter.py
@@ -22,9 +22,9 @@ class _ShadingParameterBase(object):
 
     def scale(self, factor):
         """Get a scaled version of these ShadingParameters.
-        
+
         This method is called within the scale methods of the Room2D.
-        
+
         Args:
             factor: A number representing how much the object should be scaled.
         """
@@ -65,17 +65,16 @@ class _ShadingParameterBase(object):
 class ExtrudedBorder(_ShadingParameterBase):
     """Instructions for extruded borders over all windows in the wall.
 
+    Args:
+        depth: A number for the depth of the border.
+
     Properties:
         * depth
     """
     __slots__ = ('_depth',)
 
     def __init__(self, depth):
-        """Instructions for extruded borders over all windows in the wall.
-
-        Args:
-            depth: A number for the depth of the border.
-        """
+        """Instructions for extruded borders over all windows in the wall."""
         self._depth = float_positive(depth, 'overhang width')
 
     @property
@@ -96,9 +95,9 @@ class ExtrudedBorder(_ShadingParameterBase):
 
     def scale(self, factor):
         """Get a scaled version of these ShadingParameters.
-        
+
         This method is called within the scale methods of the Room2D.
-        
+
         Args:
             factor: A number representing how much the object should be scaled.
         """
@@ -147,6 +146,12 @@ class ExtrudedBorder(_ShadingParameterBase):
 class Overhang(_ShadingParameterBase):
     """Instructions for a single overhang over an entire wall.
 
+    Args:
+        depth: A number for the overhang depth.
+        angle: A number for the for an angle to rotate the overhang in degrees.
+            Positive values indicate a downward rotation. Negative values indicate
+            an upward rotation. Default is 0 for no rotation.
+
     Properties:
         * depth
         * angle
@@ -154,14 +159,7 @@ class Overhang(_ShadingParameterBase):
     __slots__ = ('_depth', '_angle')
 
     def __init__(self, depth, angle=0):
-        """Instructions for a single overhang over an entire wall.
-
-        Args:
-            depth: A number for the overhang depth.
-            angle: A number for the for an angle to rotate the overhang in degrees.
-                Positive values indicate a downward rotation. Negative values indicate
-                an upward rotation. Default is 0 for no rotation.
-        """
+        """Instructions for a single overhang over an entire wall."""
         self._depth = float_positive(depth, 'overhang width')
         self._angle = float_in_range(angle, -90, 90, 'overhang angle')
 
@@ -189,7 +187,7 @@ class Overhang(_ShadingParameterBase):
         """Get a scaled version of these ShadingParameters.
 
         This method is called within the scale methods of the Room2D.
-        
+
         Args:
             factor: A number representing how much the object should be scaled.
         """
@@ -241,6 +239,21 @@ class Overhang(_ShadingParameterBase):
 class _LouversBase(_ShadingParameterBase):
     """Instructions for a series of louvered Shades over a Face.
 
+    Args:
+        depth: A number for the depth to extrude the louvers.
+        offset: A number for the distance to louvers from this Face.
+            Default is 0 for no offset.
+        angle: A number for the for an angle to rotate the louvers in degrees.
+            Default is 0 for no rotation.
+        contour_vector: A Vector2D for the direction along which contours
+            are generated. This 2D vector will be interpreted into a 3D vector
+            within the plane of this Face. (0, 1) will usually generate
+            horizontal contours in 3D space, (1, 0) will generate vertical
+            contours, and (1, 1) will generate diagonal contours. Default: (0, 1).
+        flip_start_side: Boolean to note whether the side the louvers start from
+            should be flipped. Default is False to have contours on top or right.
+            Setting to True will start contours on the bottom or left.
+
     Properties:
         * depth
         * offset
@@ -252,23 +265,7 @@ class _LouversBase(_ShadingParameterBase):
 
     def __init__(self, depth, offset=0, angle=0, contour_vector=Vector2D(0, 1),
                  flip_start_side=False):
-        """Initialize LouversBase.
-
-        Args:
-            depth: A number for the depth to extrude the louvers.
-            offset: A number for the distance to louvers from this Face.
-                Default is 0 for no offset.
-            angle: A number for the for an angle to rotate the louvers in degrees.
-                Default is 0 for no rotation.
-            contour_vector: A Vector2D for the direction along which contours
-                are generated. This 2D vector will be interpreted into a 3D vector
-                within the plane of this Face. (0, 1) will usually generate
-                horizontal contours in 3D space, (1, 0) will generate vertical
-                contours, and (1, 1) will generate diagonal contours. Default: (0, 1).
-            flip_start_side: Boolean to note whether the side the louvers start from
-                should be flipped. Default is False to have contours on top or right.
-                Setting to True will start contours on the bottom or left.
-        """
+        """Initialize LouversBase."""
         self._depth = float_positive(depth, 'louver depth')
         self._offset = float_positive(offset, 'louver offset')
         self._angle = float_in_range(angle, -90, 90, 'overhang angle')
@@ -337,6 +334,22 @@ class _LouversBase(_ShadingParameterBase):
 class LouversByDistance(_LouversBase):
     """Instructions for a series of louvered Shades at a given distance between.
 
+    Args:
+        distance: A number for the approximate distance between each louver.
+        depth: A number for the depth to extrude the louvers.
+        offset: A number for the distance to louvers from the wall.
+            Default is 0 for no offset.
+        angle: A number for the for an angle to rotate the louvers in degrees.
+            Default is 0 for no rotation.
+        contour_vector: A Vector2D for the direction along which contours
+            are generated. This 2D vector will be interpreted into a 3D vector
+            within the plane of the wall. (0, 1) will usually generate
+            horizontal contours in 3D space, (1, 0) will generate vertical
+            contours, and (1, 1) will generate diagonal contours. Default: (0, 1).
+        flip_start_side: Boolean to note whether the side the louvers start from
+            should be flipped. Default is False to have contours on top or right.
+            Setting to True will start contours on the bottom or left.
+
     Properties:
         * distance
         * depth
@@ -349,24 +362,7 @@ class LouversByDistance(_LouversBase):
 
     def __init__(self, distance, depth, offset=0, angle=0,
                  contour_vector=Vector2D(0, 1), flip_start_side=False):
-        """Initialize LouversByDistance.
-
-        Args:
-            distance: A number for the approximate distance between each louver.
-            depth: A number for the depth to extrude the louvers.
-            offset: A number for the distance to louvers from the wall.
-                Default is 0 for no offset.
-            angle: A number for the for an angle to rotate the louvers in degrees.
-                Default is 0 for no rotation.
-            contour_vector: A Vector2D for the direction along which contours
-                are generated. This 2D vector will be interpreted into a 3D vector
-                within the plane of the wall. (0, 1) will usually generate
-                horizontal contours in 3D space, (1, 0) will generate vertical
-                contours, and (1, 1) will generate diagonal contours. Default: (0, 1).
-            flip_start_side: Boolean to note whether the side the louvers start from
-                should be flipped. Default is False to have contours on top or right.
-                Setting to True will start contours on the bottom or left.
-        """
+        """Initialize LouversByDistance."""
         self._distance = float_positive(distance, 'louver separation distance')
         _LouversBase.__init__(self, depth, offset, angle,
                               contour_vector, flip_start_side)
@@ -392,7 +388,7 @@ class LouversByDistance(_LouversBase):
         """Get a scaled version of these ShadingParameters.
 
         This method is called within the scale methods of the Room2D.
-        
+
         Args:
             factor: A number representing how much the object should be scaled.
         """
@@ -459,6 +455,22 @@ class LouversByDistance(_LouversBase):
 class LouversByCount(_LouversBase):
     """Instructions for a specific number of louvered Shades over a wall.
 
+    Args:
+        louver_count: A positive integer for the number of louvers to generate.
+        depth: A number for the depth to extrude the louvers.
+        offset: A number for the distance to louvers from  the wall.
+            Default is 0 for no offset.
+        angle: A number for the for an angle to rotate the louvers in degrees.
+            Default is 0 for no rotation.
+        contour_vector: A Vector2D for the direction along which contours
+            are generated. This 2D vector will be interpreted into a 3D vector
+            within the plane of the wall. (0, 1) will usually generate
+            horizontal contours in 3D space, (1, 0) will generate vertical
+            contours, and (1, 1) will generate diagonal contours. Default: (0, 1).
+        flip_start_side: Boolean to note whether the side the louvers start from
+            should be flipped. Default is False to have contours on top or right.
+            Setting to True will start contours on the bottom or left.
+
     Properties:
         * louver_count
         * depth
@@ -471,24 +483,7 @@ class LouversByCount(_LouversBase):
 
     def __init__(self, louver_count, depth, offset=0, angle=0,
                  contour_vector=Vector2D(0, 1), flip_start_side=False):
-        """Initialize LouversByCount.
-
-        Args:
-            louver_count: A positive integer for the number of louvers to generate.
-            depth: A number for the depth to extrude the louvers.
-            offset: A number for the distance to louvers from  the wall.
-                Default is 0 for no offset.
-            angle: A number for the for an angle to rotate the louvers in degrees.
-                Default is 0 for no rotation.
-            contour_vector: A Vector2D for the direction along which contours
-                are generated. This 2D vector will be interpreted into a 3D vector
-                within the plane of the wall. (0, 1) will usually generate
-                horizontal contours in 3D space, (1, 0) will generate vertical
-                contours, and (1, 1) will generate diagonal contours. Default: (0, 1).
-            flip_start_side: Boolean to note whether the side the louvers start from
-                should be flipped. Default is False to have contours on top or right.
-                Setting to True will start contours on the bottom or left.
-        """
+        """Initialize LouversByCount."""
         self._louver_count = int_positive(louver_count, 'louver count')
         _LouversBase.__init__(self, depth, offset, angle,
                               contour_vector, flip_start_side)
@@ -514,7 +509,7 @@ class LouversByCount(_LouversBase):
         """Get a scaled version of these ShadingParameters.
 
         This method is called within the scale methods of the Room2D.
-        
+
         Args:
             factor: A number representing how much the object should be scaled.
         """

--- a/dragonfly/story.py
+++ b/dragonfly/story.py
@@ -15,6 +15,17 @@ from ladybug_geometry.geometry3d.polyface import Polyface3D
 class Story(_BaseGeometry):
     """A Story of a building defined by an extruded Room2Ds.
 
+    Args:
+        name: Story name. Must be < 100 characters.
+        room_2ds: An array of dragonfly Room2D objects that together form an
+            entire story of a building.
+        floor_to_floor_height: A number for the distance from the floor plate of
+            this Story to the floor of the story above this one (if it exists).
+            If None, this value will be the maximum floor_to_ceiling_height of the
+            input room_2ds.
+        multiplier: An integer that denotes the number of times that this
+            Story is repeated over the height of the building. Default: 1.
+
     Properties:
         * name
         * display_name
@@ -34,19 +45,7 @@ class Story(_BaseGeometry):
     __slots__ = ('_room_2ds', '_floor_to_floor_height', '_multiplier', '_parent')
 
     def __init__(self, name, room_2ds, floor_to_floor_height=None, multiplier=1):
-        """A Story of a building defined by an extruded Floor2Ds.
-
-        Args:
-            name: Story name. Must be < 100 characters.
-            room_2ds: An array of dragonfly Room2D objects that together form an
-                entire story of a building.
-            floor_to_floor_height: A number for the distance from the floor plate of
-                this Story to the floor of the story above this one (if it exists).
-                If None, this value will be the maximum floor_to_ceiling_height of the
-                input room_2ds.
-            multiplier: An integer that denotes the number of times that this
-                Story is repeated over the height of the building. Default: 1.
-        """
+        """A Story of a building defined by an extruded Floor2Ds."""
         _BaseGeometry.__init__(self, name)  # process the name
 
         # process the story geometry
@@ -121,8 +120,8 @@ class Story(_BaseGeometry):
         greatly speed up the calculation.
 
         For more information on multipliers in EnergyPlus see EnergyPlus Tips and Tricks:
-        https://bigladdersoftware.com/epx/docs/9-1/tips-and-tricks-using-energyplus/
-        using-multipliers-zone-and-or-window.html
+        https://bigladdersoftware.com/epx/docs/9-1/tips-and-tricks-using-energyplus/\
+using-multipliers-zone-and-or-window.html
         """
         return self._multiplier
 
@@ -180,20 +179,20 @@ class Story(_BaseGeometry):
         Note that this property is for one story and does NOT use the multiplier.
         """
         return sum([room.exterior_aperture_area for room in self._room_2ds])
-    
+
     @property
     def min(self):
         """Get a Point2D for the min bounding rectangle vertex in the XY plane.
-        
+
         This is useful in calculations to determine if this Story is in proximity
         to others.
         """
         return self._calculate_min(self._room_2ds)
-    
+
     @property
     def max(self):
         """Get a Point2D for the max bounding rectangle vertex in the XY plane.
-        
+
         This is useful in calculations to determine if this Story is in proximity
         to others.
         """
@@ -245,10 +244,10 @@ class Story(_BaseGeometry):
         else:
             raise ValueError('Room2D "{}" was not found in the story "{}"'
                              '.'.format(room_name, self.name))
-    
+
     def rooms_by_name(self, room_names):
         """Get a list of Room2D objects in this story given Room2D names.
-        
+
         Args:
             room_name: Array of strings for the names of the Room2D to be retrieved
                 from this Story.
@@ -266,7 +265,7 @@ class Story(_BaseGeometry):
 
     def add_prefix(self, prefix):
         """Change the name of this object and all child Room2Ds by inserting a prefix.
-        
+
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object
         into one Model (like making a model of repeated stories) since all objects
@@ -340,10 +339,10 @@ class Story(_BaseGeometry):
         """Set all of the outdoor walls to have the same shading parameters."""
         for room in self._room_2ds:
             room.set_outdoor_shading_parameters(shading_parameter)
-    
+
     def set_ground_contact(self, is_ground_contact=True):
         """Set all child Room2Ds of this object to have floors in contact with the ground.
-        
+
         Args:
             is_ground_contact: A boolean noting whether all the Story's room_2ds
                 have floors in contact with the ground. Default: True.
@@ -353,7 +352,7 @@ class Story(_BaseGeometry):
 
     def set_top_exposed(self, is_top_exposed=True):
         """Set all child Room2Ds of this object to have ceilings exposed to the outdoors.
-        
+
         Args:
             is_top_exposed: A boolean noting whether all the Story's room_2ds
                 have ceilings exposed to the outdoors. Default: True.

--- a/dragonfly/subdivide.py
+++ b/dragonfly/subdivide.py
@@ -22,9 +22,12 @@ def interpret_floor_height_subdivide(floor_to_floor_heights, max_height,
         first_floor_height: The z-value of the first floor.
 
     Returns:
-        floor_heights -- An array of float values for the floor heights, which
+        A tuple with two elements
+
+        -   floor_heights -- An array of float values for the floor heights, which
             can be used to generate planes that subdivide a building mass.
-        interpreted_f2f -- An array of float values noting the distance between
+
+        -   interpreted_f2f -- An array of float values noting the distance between
             each floor. Note that, unlike the input floor_to_floor_heights,
             this array always has float values and is the same length as the
             floor_heights.
@@ -85,7 +88,7 @@ def interpret_core_perimeter_subdivide(perimeter_depths, floor_count):
 
     Returns:
         An array of float values for perimeter depths, which can be used to offset
-            perimeters over a building's stories.
+        perimeters over a building's stories.
     """
     # generate the list of depth float values
     interpreted_depths = []

--- a/dragonfly/windowparameter.py
+++ b/dragonfly/windowparameter.py
@@ -36,9 +36,9 @@ class _WindowParameterBase(object):
 
     def scale(self, factor):
         """Get a scaled version of these WindowParameters.
-        
+
         This method is called within the scale methods of the Room2D.
-        
+
         Args:
             factor: A number representing how much the object should be scaled.
         """
@@ -85,15 +85,15 @@ class SingleWindow(_WindowParameterBase):
     setting the width to be `float('inf')` will create parameters that always
     generate a ribboin window of the input height.
 
-    Properties:
-        * width
-        * height
-        * sill_height
-
     Args:
         width: A number for the window width.
         height: A number for the window height.
         sill_height: A number for the window sill height. Default: 1.
+
+    Properties:
+        * width
+        * height
+        * sill_height
     """
     __slots__ = ('_width', '_height', '_sill_height')
 
@@ -160,9 +160,9 @@ class SingleWindow(_WindowParameterBase):
 
     def scale(self, factor):
         """Get a scaled version of these WindowParameters.
-        
+
         This method is called within the scale methods of the Room2D.
-        
+
         Args:
             factor: A number representing how much the object should be scaled.
         """
@@ -309,13 +309,6 @@ class SimpleWindowRatio(_WindowParameterBase):
 class RepeatingWindowRatio(SimpleWindowRatio):
     """Instructions for repeating windows derived from an area ratio with the base surface.
 
-    Properties:
-        * window_ratio
-        * window_height
-        * sill_height
-        * horizontal_separation
-        * vertical_separation
-
     Args:
         window_ratio: A number between 0 and 1 for the ratio between the window
             area and the total facade area.
@@ -332,6 +325,13 @@ class RepeatingWindowRatio(SimpleWindowRatio):
             the parent rectangle base, only one window will be produced.
         vertical_separation: An optional number to create a single vertical
             separation between top and bottom windows. Default: 0.
+
+    Properties:
+        * window_ratio
+        * window_height
+        * sill_height
+        * horizontal_separation
+        * vertical_separation
     """
     __slots__ = ('_window_height', '_sill_height',
                  '_horizontal_separation', '_vertical_separation')
@@ -390,9 +390,9 @@ class RepeatingWindowRatio(SimpleWindowRatio):
 
     def scale(self, factor):
         """Get a scaled version of these WindowParameters.
-        
+
         This method is called within the scale methods of the Room2D.
-        
+
         Args:
             factor: A number representing how much the object should be scaled.
         """
@@ -464,12 +464,6 @@ class RepeatingWindowWidthHeight(_WindowParameterBase):
     This class effectively fills a wall with windows at the specified width, height
     and separation.
 
-    Properties:
-        * window_height
-        * window_width
-        * sill_height
-        * horizontal_separation
-
     Args:
         window_height: A number for the target height of the windows.
             Note that, if the window_height is larger than the height of the wall,
@@ -486,6 +480,12 @@ class RepeatingWindowWidthHeight(_WindowParameterBase):
         horizontal_separation: A number for the target separation between
             individual window centerlines.  If this number is larger than
             the parent rectangle base, only one window will be produced.
+
+    Properties:
+        * window_height
+        * window_width
+        * sill_height
+        * horizontal_separation
     """
     __slots__ = ('_window_height', '_window_width', '_sill_height',
                  '_horizontal_separation')
@@ -541,9 +541,9 @@ class RepeatingWindowWidthHeight(_WindowParameterBase):
 
     def scale(self, factor):
         """Get a scaled version of these WindowParameters.
-        
+
         This method is called within the scale methods of the Room2D.
-        
+
         Args:
             factor: A number representing how much the object should be scaled.
         """
@@ -634,11 +634,6 @@ class RectangularWindows(_AsymmetricBase):
     certain pattern of repating rectangular windows can be encoded in a single
     RectangularWindows instance and applied to multiple Room2D segments.
 
-    Properties:
-        * origins
-        * widths
-        * heights
-
     Args:
         origins: An array of ladybug_geometry Point2D objects within the plane
             of the wall for the origin of each window. The wall plane is assumed
@@ -650,6 +645,11 @@ class RectangularWindows(_AsymmetricBase):
             of this list must match the length of the origins.
         heights: An array of postive numbers for the window heights. The length
             of this list must match the length of the origins.
+
+    Properties:
+        * origins
+        * widths
+        * heights
     """
     __slots__ = ('_origins', '_widths', '_heights')
 
@@ -661,7 +661,7 @@ class RectangularWindows(_AsymmetricBase):
             assert isinstance(point, Point2D), \
                 'Expected Point2D for window origin. Got {}'.format(type(point))
         self._origins = origins
-        
+
         self._widths = tuple(float_positive(width, 'window width') for width in widths)
         self._heights = tuple(float_positive(hgt, 'window height') for hgt in heights)
 
@@ -737,9 +737,9 @@ class RectangularWindows(_AsymmetricBase):
 
     def scale(self, factor):
         """Get a scaled version of these WindowParameters.
-        
+
         This method is called within the scale methods of the Room2D.
-        
+
         Args:
             factor: A number representing how much the object should be scaled.
         """
@@ -830,9 +830,6 @@ class DetailedWindows(_AsymmetricBase):
     performs no automatic checks to ensure that the windows lie within the
     boundary of the wall they have been assigned to.
 
-    Properties:
-        * polygons
-
     Args:
         polygons: An array of ladybug_geometry Polygon2D objects within the plane
             of the wall with one polygon for each window. The wall plane is
@@ -840,7 +837,10 @@ class DetailedWindows(_AsymmetricBase):
             and an X-axis extending along the length of the segment. The wall
             plane's Y-axis always points upwards.  Therefore, both X and Y
             values of each point in the polygon should always be positive.
-    
+
+    Properties:
+        * polygons
+
     Usage:
         Note that, if you are starting from 3D vertices of windows, you can
         use this class to represent them. Below is some sample code to convert from
@@ -921,9 +921,9 @@ class DetailedWindows(_AsymmetricBase):
 
     def scale(self, factor):
         """Get a scaled version of these WindowParameters.
-        
+
         This method is called within the scale methods of the Room2D.
-        
+
         Args:
             factor: A number representing how much the object should be scaled.
         """


### PR DESCRIPTION
Hi @chriswmackey,

I started with this library and I stumbled upon a couple of issues when generating the pages that I hope you can help me with:

1)  
Extension error:
Could not import extension sphinx_click.ext (exception: No module named click)
From the conf.py file I noticed the need of the sphinx-click extension so I installed it through pip:  pip install sphinx-click. 
At that point the message still comes up on the sphinx build command. I'm sure I'm missing a library or something. Any suggestions?

2)
When I disabled the sphinx-click extension to generate the pages that don't need it found this error:
Traceback (most recent call last):
  File "c:\python27\lib\site-packages\sphinx\ext\autodoc\importer.py", line 154, in import_module
    __import__(modname)
  File "C:\Users\sgara\Documents\GitHub\dragonfly-core\dragonfly\model.py", line 19, in <module>
    class Model(_BaseGeometry):
  File "C:\Users\sgara\Documents\GitHub\dragonfly-core\dragonfly\model.py", line 64, in Model
    UNITS = hb_model.UNITS
AttributeError: type object 'Model' has no attribute 'UNITS'
If I understand this right seems to be pointing to the honeybee.MODEL class. There is no UNITS property in it. Is this a bug?
