### PR TITLE
feat(cli): Add command to solve adjacency across a Model

### DIFF
--- a/dragonfly/cli/__init__.py
+++ b/dragonfly/cli/__init__.py
@@ -53,6 +53,7 @@ except ImportError:
     )
 
 from dragonfly.cli.validate import validate
+from dragonfly.cli.edit import edit
 
 
 @click.group()
@@ -68,6 +69,7 @@ def viz():
 
 
 main.add_command(validate)
+main.add_command(edit)
 
 
 if __name__ == "__main__":

--- a/dragonfly/cli/edit.py
+++ b/dragonfly/cli/edit.py
@@ -1,0 +1,87 @@
+"""dragonfly model editing commands."""
+
+try:
+    import click
+except ImportError:
+    raise ImportError(
+        'click is not installed. Try `pip install . [cli]` command.'
+    )
+
+from dragonfly.model import Model
+from honeybee.boundarycondition import boundary_conditions as bcs
+try:
+    ad_bc = bcs.adiabatic
+except: # honeybee_energy is not loaded and adiabatic does not exist
+    ad_bc = None
+
+
+import sys
+import os
+import logging
+import json
+
+_logger = logging.getLogger(__name__)
+
+
+@click.group(help='Commands for editing Dragonfly models.')
+def edit():
+    pass
+
+
+@edit.command('solve-adjacency')
+@click.argument('model-json')
+@click.argument('adiabatic', type=bool, default=False)
+@click.option('--included-prop', help='List of properties to filter keys that must '
+              'be included in output JSON. For example ["energy"] will include '
+              '"energy" key if available. By default, all the keys will be'
+              'included. To exclude all the keys from extensions, use an empty list.',
+              type=list, default=None)
+@click.option('--log-file', help='Optional log file to output the Model JSON string'
+              ' with solved adjacency. By default it will be printed out to stdout',
+              type=click.File('w'), default='-')
+def solve_adjacency(model_json, adiabatic, included_prop, log_file):
+    """Solve adjacency between Room2Ds of a Model JSON file. This includes 3 steps.\n
+    1. Remove colinear vertices from the Room2D polygons.\n
+    2. Intersect adjacent segments of the same Story with one another.\n
+    3. Set Surface boundary conditions for all matching segments across each Story.\n
+    \n
+    Note that this command removes all existing boundary_conditions, window_parameters,
+    and shading_parameters so it is recommended that this method be used at the
+    beginning of model creation.
+    \n
+    Args:
+        model_json: Full path to a Model JSON file.\n
+        adiabatic: Boolean to note whether adjacencies should be adiabatic.
+    """
+    try:
+        assert os.path.isfile(model_json), 'No JSON file found at {}.'.format(model_json)
+
+        # serialze the Model to Python
+        with open(model_json) as json_file:
+            data = json.load(json_file)
+        parsed_model = Model.from_dict(data)
+
+        # check the Model tolerance
+        assert parsed_model.tolerance != 0, \
+            'Model must have a non-zero tolerance to use solve-adjacency.'
+        tol = parsed_model.tolerance
+
+        # process the adjacency of each story
+        for bldg in parsed_model.buildings:
+            for story in bldg.unique_stories:
+                story.remove_room_2d_colinear_vertices(tol)
+                story.intersect_room_2d_adjacency(tol)
+                adj_info = story.solve_room_2d_adjacency(tol)
+                if adiabatic and ad_bc:
+                    for face_pair in adj_info:
+                        face_pair[0][0].set_boundary_condition(face_pair[0][1], ad_bc)
+                        face_pair[1][0].set_boundary_condition(face_pair[1][1], ad_bc)
+        
+        # write the new model out to the file or stdout
+        log_file.write(json.dumps(parsed_model.to_dict(included_prop)))
+
+    except Exception as e:
+        _logger.exception('Model solve adjacency failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)

--- a/dragonfly/cli/validate.py
+++ b/dragonfly/cli/validate.py
@@ -32,7 +32,7 @@ def validate():
 @click.argument('model-json')
 def validate_model(model_json):
     """Validate a Model JSON file against the Dragonfly schema.
-    \b
+    \n
     Args:
         model_json: Full path to a Model JSON file.
     """

--- a/dragonfly/model.py
+++ b/dragonfly/model.py
@@ -621,6 +621,12 @@ class Model(_BaseGeometry):
                 [shd.to_dict(True, included_prop) for shd in self._context_shades]
         if self.north_angle != 0:
             base['north_angle'] = self.north_angle
+        if self.units != 'Meters':
+            base['units'] = self.units
+        if self.tolerance != 0:
+            base['tolerance'] = self.tolerance
+        if self.angle_tolerance != 0:
+            base['angle_tolerance'] = self.angle_tolerance
 
         return base
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,7 +1,14 @@
 """Test cli."""
-
 from click.testing import CliRunner
+
 from dragonfly.cli import viz
+from dragonfly.cli.validate import validate_model
+from dragonfly.cli.edit import solve_adjacency
+
+from dragonfly.model import Model
+from honeybee.boundarycondition import Surface
+
+import json
 
 
 def test_viz():
@@ -10,3 +17,14 @@ def test_viz():
     assert result.exit_code == 0
     assert result.output.startswith('vi')
     assert result.output.endswith('z!\n')
+
+
+def test_edit_solve_adjacency():
+    input_model = './tests/json/sample_revit_model.json'
+    runner = CliRunner()
+    result = runner.invoke(solve_adjacency, [input_model])
+    assert result.exit_code == 0
+
+    result_model = Model.from_dict(json.loads(result.output))
+    rooms = result_model.buildings[0].unique_room_2ds
+    assert isinstance(rooms[0].boundary_conditions[0], Surface)

--- a/tests/json/sample_revit_model.json
+++ b/tests/json/sample_revit_model.json
@@ -1,0 +1,546 @@
+{
+    "type": "Model",
+    "name": "SampleModel",
+    "display_name": "Sample Model",
+    "properties": {
+        "type": "ModelProperties"
+    },
+    "buildings": [
+        {
+            "type": "Building",
+            "name": "SampleBuilding",
+            "display_name": "Sample Building",
+            "unique_stories": [
+                {
+                    "type": "Story",
+                    "name": "GroundFloor",
+                    "display_name": "Ground Floor",
+                    "room_2ds": [
+                        {
+                            "type": "Room2D",
+                            "name": "KitchenDining",
+                            "display_name": "Kitchen & Dining 101",
+                            "properties": {
+                                "type": "Room2DPropertiesAbridged"
+                            },
+                            "floor_boundary": [
+                                [
+                                    22.89347610707884,
+                                    -2.441417252564399
+                                ],
+                                [
+                                    22.89347610707885,
+                                    4.0630118812932645
+                                ],
+                                [
+                                    22.506336999467308,
+                                    4.063011881293265
+                                ],
+                                [
+                                    22.506336999467308,
+                                    4.565011881293264
+                                ],
+                                [
+                                    22.506336999467308,
+                                    9.010486946911806
+                                ],
+                                [
+                                    22.506336999467308,
+                                    9.512486946911878
+                                ],
+                                [
+                                    -16.201012081897545,
+                                    9.512486946917903
+                                ],
+                                [
+                                    -16.201012081897584,
+                                    -10.503917252564468
+                                ],
+                                [
+                                    22.89347610707883,
+                                    -10.503917252564593
+                                ],
+                                [
+                                    22.89347610707883,
+                                    -10.963234837866429
+                                ],
+                                [
+                                    25.0737582593098,
+                                    -10.963234837866437
+                                ],
+                                [
+                                    25.073758259309813,
+                                    -2.441417252564406
+                                ]
+                            ],
+                            "floor_holes": [
+                                [
+                                    [
+                                        0.20318739316808276,
+                                        -0.6613975675253417
+                                    ],
+                                    [
+                                        -0.2772804854629076,
+                                        -1.8213496364009123
+                                    ],
+                                    [
+                                        -1.4372325543384774,
+                                        -2.301817515031905
+                                    ],
+                                    [
+                                        -2.597184623214048,
+                                        -1.8213496364009145
+                                    ],
+                                    [
+                                        -3.0776525018450407,
+                                        -0.6613975675253477
+                                    ],
+                                    [
+                                        -2.597184623214053,
+                                        0.4985545013502233
+                                    ],
+                                    [
+                                        -1.4372325543384852,
+                                        0.9790223799812185
+                                    ],
+                                    [
+                                        -0.2772804854629143,
+                                        0.4985545013502324
+                                    ]
+                                ]
+                            ],
+                            "floor_height": 0.0,
+                            "floor_to_ceiling_height": 8.858267716535433,
+                            "is_ground_contact": false,
+                            "is_top_exposed": false,
+                            "boundary_conditions": [
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Room2D",
+                            "name": "Laundry",
+                            "display_name": "Laundry 104",
+                            "properties": {
+                                "type": "Room2DPropertiesAbridged"
+                            },
+                            "floor_boundary": [
+                                [
+                                    32.758961671383304,
+                                    -2.4414172525644307
+                                ],
+                                [
+                                    27.19823203528922,
+                                    -2.4414172525644124
+                                ],
+                                [
+                                    25.073758259309813,
+                                    -2.441417252564406
+                                ],
+                                [
+                                    25.0737582593098,
+                                    -10.963234837866437
+                                ],
+                                [
+                                    32.75896167138329,
+                                    -10.96323483786646
+                                ],
+                                [
+                                    32.75896167138329,
+                                    -8.213891005844893
+                                ]
+                            ],
+                            "floor_holes": [],
+                            "floor_height": 0.0,
+                            "floor_to_ceiling_height": 8.758267716535434,
+                            "is_ground_contact": false,
+                            "is_top_exposed": false,
+                            "boundary_conditions": [
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Room2D",
+                            "name": "Bath",
+                            "display_name": "Bath 103",
+                            "properties": {
+                                "type": "Room2DPropertiesAbridged"
+                            },
+                            "floor_boundary": [
+                                [
+                                    32.75896167138331,
+                                    4.007237603078009
+                                ],
+                                [
+                                    27.19823203528923,
+                                    4.0072376030780275
+                                ],
+                                [
+                                    27.19823203528922,
+                                    -2.4414172525644124
+                                ],
+                                [
+                                    32.758961671383304,
+                                    -2.4414172525644307
+                                ]
+                            ],
+                            "floor_holes": [],
+                            "floor_height": 0.0,
+                            "floor_to_ceiling_height": 8.758267716535434,
+                            "is_ground_contact": false,
+                            "is_top_exposed": false,
+                            "boundary_conditions": [
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Room2D",
+                            "name": "Hall",
+                            "display_name": "Hall 105",
+                            "properties": {
+                                "type": "Room2DPropertiesAbridged"
+                            },
+                            "floor_boundary": [
+                                [
+                                    33.0115863432995,
+                                    9.345164112265023
+                                ],
+                                [
+                                    33.011586343299314,
+                                    9.456712668695019
+                                ],
+                                [
+                                    22.506336999467308,
+                                    9.456712668696655
+                                ],
+                                [
+                                    22.506336999467308,
+                                    4.007237603078043
+                                ],
+                                [
+                                    27.19823203528923,
+                                    4.0072376030780275
+                                ],
+                                [
+                                    32.75896167138331,
+                                    4.007237603078009
+                                ],
+                                [
+                                    32.758961671383304,
+                                    -2.4414172525644293
+                                ],
+                                [
+                                    32.75896167138329,
+                                    -8.213891005844893
+                                ],
+                                [
+                                    32.75896167138329,
+                                    -11.422552423168298
+                                ],
+                                [
+                                    43.129696579519766,
+                                    -11.422552423168334
+                                ],
+                                [
+                                    43.129696579519766,
+                                    -10.503917252566115
+                                ],
+                                [
+                                    43.12969657951979,
+                                    4.653563062395563
+                                ],
+                                [
+                                    43.06736062151455,
+                                    4.653563062395771
+                                ],
+                                [
+                                    43.06736062151456,
+                                    9.345164112264989
+                                ]
+                            ],
+                            "floor_holes": [],
+                            "floor_height": 0.0,
+                            "floor_to_ceiling_height": 8.758267716535434,
+                            "is_ground_contact": false,
+                            "is_top_exposed": false,
+                            "boundary_conditions": [
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Room2D",
+                            "name": "Living",
+                            "display_name": "Living 106",
+                            "properties": {
+                                "type": "Room2DPropertiesAbridged"
+                            },
+                            "floor_boundary": [
+                                [
+                                    43.1296965795197,
+                                    -49.87399599272257
+                                ],
+                                [
+                                    43.129696579519766,
+                                    -11.422552423168334
+                                ],
+                                [
+                                    32.814735949598514,
+                                    -11.422552423168298
+                                ],
+                                [
+                                    32.814735949598514,
+                                    -10.96323483786646
+                                ],
+                                [
+                                    25.34982542543813,
+                                    -10.963234837866437
+                                ],
+                                [
+                                    24.797691093181466,
+                                    -10.963234837866436
+                                ],
+                                [
+                                    22.893476107078826,
+                                    -10.963234837866429
+                                ],
+                                [
+                                    22.89347610707876,
+                                    -49.873995992722506
+                                ]
+                            ],
+                            "floor_holes": [],
+                            "floor_height": 0.0,
+                            "floor_to_ceiling_height": 7.053805774278215,
+                            "is_ground_contact": false,
+                            "is_top_exposed": false,
+                            "boundary_conditions": [
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Room2D",
+                            "name": "Mech.",
+                            "display_name": "Mech. 102",
+                            "properties": {
+                                "type": "Room2DPropertiesAbridged"
+                            },
+                            "floor_boundary": [
+                                [
+                                    22.89347610707885,
+                                    4.007237603078042
+                                ],
+                                [
+                                    22.89347610707884,
+                                    -2.4414172525643987
+                                ],
+                                [
+                                    25.073758259309813,
+                                    -2.441417252564406
+                                ],
+                                [
+                                    27.19823203528922,
+                                    -2.4414172525644116
+                                ],
+                                [
+                                    27.19823203528923,
+                                    4.0072376030780275
+                                ],
+                                [
+                                    22.958336999467306,
+                                    4.007237603078042
+                                ]
+                            ],
+                            "floor_holes": [],
+                            "floor_height": 0.0,
+                            "floor_to_ceiling_height": 8.758267716535434,
+                            "is_ground_contact": false,
+                            "is_top_exposed": false,
+                            "boundary_conditions": [
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                },
+                                {
+                                    "type": "Outdoors"
+                                }
+                            ]
+                        }
+                    ],
+                    "floor_to_floor_height": 8.858267716535433,
+                    "multiplier": 1,
+                    "properties": {
+                        "type": "StoryPropertiesAbridged"
+                    }
+                }
+            ],
+            "properties": {
+                "type": "BuildingPropertiesAbridged"
+            }
+        }
+    ],
+    "units": "Feet",
+    "tolerance": 0.01,
+    "angle_tolerance": 1.0
+}

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -473,6 +473,8 @@ def test_to_dict():
 
     model = Model('New Development', [building], [tree_canopy])
     model.north_angle = 15
+    model.tolerance = 0.01
+    model.angle_tolerance = 1
 
     model_dict = model.to_dict()
     assert model_dict['type'] == 'Model'
@@ -484,6 +486,10 @@ def test_to_dict():
     assert len(model_dict['context_shades']) == 1
     assert 'north_angle' in model_dict
     assert model_dict['north_angle'] == 15
+    assert 'tolerance' in model_dict
+    assert model_dict['tolerance'] == 0.01
+    assert 'angle_tolerance' in model_dict
+    assert model_dict['angle_tolerance'] == 1
     assert 'properties' in model_dict
     assert model_dict['properties']['type'] == 'ModelProperties'
 

--- a/tests/room2d_test.py
+++ b/tests/room2d_test.py
@@ -305,6 +305,17 @@ def test_generate_grid():
     assert len(mesh_grid.faces) == 200
 
 
+def test_room2d_set_boundary_condition():
+    """Test the Room2D set_boundary_condition method."""
+    pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
+    room2d = Room2D('Square Shoebox', Face3D(pts), 3)
+    room2d.set_boundary_condition(1, bcs.ground)
+    room2d.set_boundary_condition(3, bcs.ground)
+
+    assert isinstance(room2d.boundary_conditions[1], Ground)
+    assert isinstance(room2d.boundary_conditions[3], Ground)
+
+
 def test_move():
     """Test the Room2D move method."""
     pts_1 = (Point3D(0, 2, 0), Point3D(2, 2, 0), Point3D(2, 0, 0), Point3D(0, 0, 0))
@@ -410,6 +421,20 @@ def test_reflect():
     assert test_2.floor_geometry[1].x == pytest.approx(-1, rel=1e-3)
     assert test_2.floor_geometry[1].y == pytest.approx(-1, rel=1e-3)
     assert test_2.floor_geometry[1].z == pytest.approx(2, rel=1e-3)
+
+
+def test_room2d_remove_colinear_vertices():
+    """Test the Room2D remove_colinear_vertices method."""
+    pts = (Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3),
+           Point3D(0, 10, 3))
+    room2d = Room2D('Square Shoebox', Face3D(pts), 3)
+
+    assert len(room2d) == 5
+    new_room = room2d.remove_colinear_vertices(0.01)
+    assert len(new_room) == 4
+    assert len(new_room.boundary_conditions) == 4
+    assert len(new_room.window_parameters) == 4
+    assert len(new_room.shading_parameters) == 4
 
 
 def test_room2d_solve_adjacency():


### PR DESCRIPTION
This commit adds a command that solves adjacency across a Model by removing colinera vertices, intersecting adjacent segments, and setting Surface boundary conditions for matching segments.

To use the command, the following should be done:
```
python -m dragonfly edit solve-adjacency [PATH TO MODEL JSON]
```