### PR TITLE
refactor(identifier): Change name property to identifier

### DIFF
--- a/dragonfly/properties.py
+++ b/dragonfly/properties.py
@@ -60,7 +60,7 @@ class _Properties(object):
                 raise Exception('Failed to duplicate {}: {}'.format(var, e))
 
     def _add_prefix_extension_attr(self, prefix):
-        """Change the name extension attributes unique to this object by adding a prefix.
+        """Change the identifier of attributes unique to this object by adding a prefix.
 
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object
@@ -72,8 +72,8 @@ class _Properties(object):
 
         Args:
             prefix: Text that will be inserted at the start of the extension attributes'
-                name. It is recommended that this name be short to avoid maxing
-                out the 100 allowable characters for honeybee names.
+                identifier. It is recommended that this prefix be short to avoid maxing
+                out the 100 allowable characters for honeybee identifiers.
         """
         attr = [atr for atr in dir(self)
                 if not atr.startswith('_') and atr not in self._do_not_duplicate]
@@ -128,7 +128,7 @@ class _Properties(object):
             abridged: Boolean to note whether the attributes of the extensions should
                 be abridged (True) or full (False). For example, if a Room's energy
                 properties are abridged, the program_type attribute under the energy
-                properties dictionary will just be the name of the program_type. If
+                properties dictionary will just be the identifier of the program_type. If
                 it is full (not abridged), the program_type will be a complete
                 dictionary following the ProgramType schema. Abridged dictionaries
                 should be used within the Model.to_dict but full dictionaries should
@@ -309,14 +309,15 @@ class ContextShadeProperties(_Properties):
         return self._add_extension_attr_to_honeybee(host, hb_prop)
 
     def add_prefix(self, prefix):
-        """Change the name extension attributes unique to this object by adding a prefix.
+        """Change the identifier of attributes unique to this object by adding a prefix.
 
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the ContextShade and does not add the prefix to attributes that are
         shared across several ContextShades.
 
         Args:
-            prefix: Text that will be inserted at the start of extension attribute names.
+            prefix: Text that will be inserted at the start of extension
+                attribute identifiers.
         """
         self._add_prefix_extension_attr(prefix)
 
@@ -355,14 +356,15 @@ class BuildingProperties(_Properties):
         return base
 
     def add_prefix(self, prefix):
-        """Change the name extension attributes unique to this object by adding a prefix.
+        """Change the identifier of attributes unique to this object by adding a prefix.
 
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the Building and does not add the prefix to attributes that are
         shared across several Buildings.
 
         Args:
-            prefix: Text that will be inserted at the start of extension attribute names.
+            prefix: Text that will be inserted at the start of extension
+                attribute identifiers.
         """
         self._add_prefix_extension_attr(prefix)
 
@@ -401,14 +403,15 @@ class StoryProperties(_Properties):
         return base
 
     def add_prefix(self, prefix):
-        """Change the name extension attributes unique to this object by adding a prefix.
+        """Change the identifier of attributes unique to this object by adding a prefix.
 
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the Story and does not add the prefix to attributes that are
         shared across several Stories.
 
         Args:
-            prefix: Text that will be inserted at the start of extension attribute names.
+            prefix: Text that will be inserted at the start of extension
+                attribute identifiers.
         """
         self._add_prefix_extension_attr(prefix)
 
@@ -456,7 +459,7 @@ class Room2DProperties(_Properties):
         return self._add_extension_attr_to_honeybee(host, hb_prop)
 
     def add_prefix(self, prefix):
-        """Change the name extension attributes unique to this object by adding a prefix.
+        """Change the identifier of attributes unique to this object by adding a prefix.
 
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the Room2D (eg. single-room HVAC systems) and does not add
@@ -464,7 +467,8 @@ class Room2DProperties(_Properties):
         ConstructionSets).
 
         Args:
-            prefix: Text that will be inserted at the start of extension attribute names.
+            prefix: Text that will be inserted at the start of extension
+                attribute identifiers.
         """
         self._add_prefix_extension_attr(prefix)
 

--- a/dragonfly/windowparameter.py
+++ b/dragonfly/windowparameter.py
@@ -155,10 +155,10 @@ class SingleWindow(_WindowParameterBase):
             face.aperture_by_width_height(final_width, final_height, self.sill_height)
             # if the Aperture is interior, set adjacent boundary condition
             if isinstance(face._boundary_condition, Surface):
-                names = face._boundary_condition.boundary_condition_objects
-                adj_ap_name = '{}_Glz1'.format(names[0])
-                final_names = (adj_ap_name,) + names
-                face.apertures[0].boundary_condition = Surface(final_names, True)
+                ids = face._boundary_condition.boundary_condition_objects
+                adj_ap_id = '{}_Glz1'.format(ids[0])
+                final_ids = (adj_ap_id,) + ids
+                face.apertures[0].boundary_condition = Surface(final_ids, True)
 
     def scale(self, factor):
         """Get a scaled version of these WindowParameters.
@@ -258,15 +258,15 @@ class SimpleWindowRatio(_WindowParameterBase):
         """
         scale_factor = self.window_ratio ** .5
         ap_face = face.geometry.scale(scale_factor, face.geometry.center)
-        aperture = Aperture('{}_Glz1'.format(face.display_name), ap_face)
+        aperture = Aperture('{}_Glz1'.format(face.identifier), ap_face)
         aperture._parent = face
         face.add_aperture(aperture)
         # if the Aperture is interior, set adjacent boundary condition
         if isinstance(face._boundary_condition, Surface):
-            names = face._boundary_condition.boundary_condition_objects
-            adj_ap_name = '{}_Glz1'.format(names[0])
-            final_names = (adj_ap_name,) + names
-            aperture.boundary_condition = Surface(final_names, True)
+            ids = face._boundary_condition.boundary_condition_objects
+            adj_ap_id = '{}_Glz1'.format(ids[0])
+            final_ids = (adj_ap_id,) + ids
+            aperture.boundary_condition = Surface(final_ids, True)
 
     @classmethod
     def from_dict(cls, data):
@@ -385,10 +385,10 @@ class RepeatingWindowRatio(SimpleWindowRatio):
         if isinstance(face._boundary_condition, Surface):
             num_aps = face.apertures
             for i, ap in enumerate(face.apertures):
-                names = face._boundary_condition.boundary_condition_objects
-                adj_ap_name = '{}_Glz{}'.format(names[0], num_aps - i - 1)
-                final_names = (adj_ap_name,) + names
-                ap.boundary_condition = Surface(final_names, True)
+                ids = face._boundary_condition.boundary_condition_objects
+                adj_ap_id = '{}_Glz{}'.format(ids[0], num_aps - i - 1)
+                final_ids = (adj_ap_id,) + ids
+                ap.boundary_condition = Surface(final_ids, True)
 
     def scale(self, factor):
         """Get a scaled version of these WindowParameters.
@@ -536,10 +536,10 @@ class RepeatingWindowWidthHeight(_WindowParameterBase):
         if isinstance(face._boundary_condition, Surface):
             num_aps = face.apertures
             for i, ap in enumerate(face.apertures):
-                names = face._boundary_condition.boundary_condition_objects
-                adj_ap_name = '{}_Glz{}'.format(names[0], num_aps - i - 1)
-                final_names = (adj_ap_name,) + names
-                ap.boundary_condition = Surface(final_names, True)
+                ids = face._boundary_condition.boundary_condition_objects
+                adj_ap_id = '{}_Glz{}'.format(ids[0], num_aps - i - 1)
+                final_ids = (adj_ap_id,) + ids
+                ap.boundary_condition = Surface(final_ids, True)
 
     def scale(self, factor):
         """Get a scaled version of these WindowParameters.
@@ -727,15 +727,15 @@ class RectangularWindows(_AsymmetricBase):
             if final_height > 0 and final_height > 0:  # inside wall boundary
                 base_plane = Plane(wall_plane.n, wall_plane.xy_to_xyz(o), wall_plane.x)
                 ap_face = Face3D.from_rectangle(final_width, final_height, base_plane)
-                aperture = Aperture('{}_Glz{}'.format(face.display_name, i + 1), ap_face)
+                aperture = Aperture('{}_Glz{}'.format(face.identifier, i + 1), ap_face)
                 aperture._parent = face
                 face.add_aperture(aperture)
                 # if the Aperture is interior, set adjacent boundary condition
                 if isinstance(face._boundary_condition, Surface):
-                    names = face._boundary_condition.boundary_condition_objects
-                    adj_ap_name = '{}_Glz{}'.format(names[0], i + 1)
-                    final_names = (adj_ap_name,) + names
-                    aperture.boundary_condition = Surface(final_names, True)
+                    ids = face._boundary_condition.boundary_condition_objects
+                    adj_ap_id = '{}_Glz{}'.format(ids[0], i + 1)
+                    final_ids = (adj_ap_id,) + ids
+                    aperture.boundary_condition = Surface(final_ids, True)
 
     def scale(self, factor):
         """Get a scaled version of these WindowParameters.
@@ -911,15 +911,15 @@ class DetailedWindows(_AsymmetricBase):
         # loop through each window and create its geometry
         for i, polygon in enumerate(self.polygons):
             pt3d = tuple(wall_plane.xy_to_xyz(pt) for pt in polygon)
-            aperture = Aperture('{}_Glz{}'.format(face.display_name, i + 1), Face3D(pt3d))
+            aperture = Aperture('{}_Glz{}'.format(face.identifier, i + 1), Face3D(pt3d))
             aperture._parent = face
             face.add_aperture(aperture)
             # if the Aperture is interior, set adjacent boundary condition
             if isinstance(face._boundary_condition, Surface):
-                names = face._boundary_condition.boundary_condition_objects
-                adj_ap_name = '{}_Glz{}'.format(names[0], i + 1)
-                final_names = (adj_ap_name,) + names
-                aperture.boundary_condition = Surface(final_names, True)
+                ids = face._boundary_condition.boundary_condition_objects
+                adj_ap_id = '{}_Glz{}'.format(ids[0], i + 1)
+                final_ids = (adj_ap_id,) + ids
+                aperture.boundary_condition = Surface(final_ids, True)
 
     def scale(self, factor):
         """Get a scaled version of these WindowParameters.

--- a/tests/building_test.py
+++ b/tests/building_test.py
@@ -21,18 +21,19 @@ def test_building_init():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('Office_Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building_1234', [story])
+    building.display_name = 'Office Building'
 
     str(building)  # test the string representation
-    assert building.name == 'OfficeBuilding'
+    assert building.identifier == 'Office_Building_1234'
     assert building.display_name == 'Office Building'
     assert len(building.unique_stories) == 1
     assert len(building.all_stories()) == 4
@@ -63,12 +64,12 @@ def test_building_init_from_footprint():
     """Test the initalization of Building objects from_footprint."""
     pts_1 = (Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(10, 10, 0), Point3D(10, 0, 0))
     pts_2 = (Point3D(0, 10, 0), Point3D(0, 20, 0), Point3D(10, 20, 0), Point3D(10, 10, 0))
-    building = Building.from_footprint('Office Tower', [Face3D(pts_1), Face3D(pts_2)],
+    building = Building.from_footprint('Office_Tower', [Face3D(pts_1), Face3D(pts_2)],
                                        [5, 4, 4, 3, 3, 3, 3, 3])
     building.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
-    assert building.name == 'OfficeTower'
-    assert building.display_name == 'Office Tower'
+    assert building.identifier == 'Office_Tower'
+    assert building.display_name == 'Office_Tower'
     assert len(building.unique_stories) == 3
     assert len(building.all_stories()) == 8
     assert len(building.unique_room_2ds) == 6
@@ -83,13 +84,13 @@ def test_building_init_from_all_story_geometry():
     pts_4 = (Point3D(0, 0, 11), Point3D(0, 10, 11), Point3D(5, 10, 11), Point3D(5, 0, 11))
     story_geo = [[Face3D(pts_1)], [Face3D(pts_2)], [Face3D(pts_3)], [Face3D(pts_4)]]
     building = Building.from_all_story_geometry(
-        'Office Tower', story_geo, [4, 4, 3, 3], 0.01)
+        'Office_Tower', story_geo, [4, 4, 3, 3], 0.01)
     building.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
     print(Building._is_story_equivalent(story_geo[0][0], story_geo[1][0], 0.1))
 
-    assert building.name == 'OfficeTower'
-    assert building.display_name == 'Office Tower'
+    assert building.identifier == 'Office_Tower'
+    assert building.display_name == 'Office_Tower'
     assert len(building.unique_stories) == 2
     assert len(building.all_stories()) == 4
     assert len(building.unique_room_2ds) == 2
@@ -102,15 +103,15 @@ def test_building_footprint_simple():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('Office_Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
 
     footprint = building.footprint(0.01)
     assert len(footprint) == 1
@@ -127,17 +128,17 @@ def test_building_footprint_courtyard():
     pts_2 = (Point3D(15, 0, 3), Point3D(15, 15, 3), Point3D(20, 15, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 5, 3), Point3D(0, 20, 3), Point3D(5, 20, 3), Point3D(5, 5, 3))
     pts_4 = (Point3D(5, 15, 3), Point3D(5, 20, 3), Point3D(20, 20, 3), Point3D(20, 15, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
     int_rms = Room2D.intersect_adjacency([room2d_1, room2d_2, room2d_3, room2d_4], 0.01)
-    story = Story('Office Floor', int_rms)
+    story = Story('Office_Floor', int_rms)
     story.rotate_xy(5, Point3D(0, 0, 0))
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
 
     footprint = building.footprint(0.01)
     assert len(footprint) == 1
@@ -154,19 +155,19 @@ def test_building_footprint_disconnect():
     pts_3 = (Point3D(0, 5, 3), Point3D(0, 20, 3), Point3D(5, 20, 3), Point3D(5, 5, 3))
     pts_4 = (Point3D(5, 15, 3), Point3D(5, 20, 3), Point3D(20, 20, 3), Point3D(20, 15, 3))
     pts_5 = (Point3D(-5, -5, 3), Point3D(-10, -5, 3), Point3D(-10, -10, 3), Point3D(-5, -10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    room2d_5 = Room2D('Office 5', Face3D(pts_5), 3)
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    room2d_5 = Room2D('Office5', Face3D(pts_5), 3)
     int_rms = Room2D.intersect_adjacency(
         [room2d_1, room2d_2, room2d_3, room2d_4, room2d_5], 0.01)
-    story = Story('Office Floor', int_rms)
+    story = Story('Office_Floor', int_rms)
     story.rotate_xy(5, Point3D(0, 0, 0))
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
 
     footprint = building.footprint(0.01)
     assert len(footprint) == 2
@@ -184,14 +185,14 @@ def test_building_shade_representation():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('Office_Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
 
     shade_rep = building.shade_representation(0.01)
     assert len(shade_rep) == 8
@@ -205,14 +206,14 @@ def test_building_window_shading_parameters():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('Office_Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
 
     assert building.exterior_aperture_area == 0
     assert building.unique_room_2ds[0].window_parameters[2] is None
@@ -231,7 +232,7 @@ def test_building_window_shading_parameters():
     assert len(building.unique_room_2ds) == 4
     building.separate_top_bottom_floors()
     assert len(building.unique_stories) == 3
-    assert len(set(story.name for story in building.unique_stories)) == 3
+    assert len(set(story.identifier for story in building.unique_stories)) == 3
     assert len(building.all_stories()) == 4
     assert len(building.unique_room_2ds) == 12
 
@@ -240,12 +241,12 @@ def test_move():
     """Test the Building move method."""
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office_1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office_2', Face3D(pts_2), 3)
+    story = Story('Office_Floor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
 
     vec_1 = Vector3D(2, 2, 2)
     new_b = building.duplicate()
@@ -268,12 +269,12 @@ def test_scale():
     """Test the Building scale method."""
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('Office_Floor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
 
     new_b = building.duplicate()
     new_b.scale(2)
@@ -295,10 +296,10 @@ def test_rotate_xy():
     """Test the Building rotate_xy method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    room = Room2D('Square Shoebox', Face3D(pts, plane), 3)
-    story = Story('Office Floor', [room])
+    room = Room2D('Square_Shoebox', Face3D(pts, plane), 3)
+    story = Story('Office_Floor', [room])
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
     origin_1 = Point3D(1, 1, 0)
 
     test_1 = building.duplicate()
@@ -329,10 +330,10 @@ def test_reflect():
     """Test the Building reflect method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    room = Room2D('Square Shoebox', Face3D(pts, plane), 3)
-    story = Story('Office Floor', [room])
+    room = Room2D('Square_Shoebox', Face3D(pts, plane), 3)
+    story = Story('Office_Floor', [room])
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
 
     origin_1 = Point3D(1, 0, 2)
     normal_1 = Vector3D(1, 0, 0)
@@ -352,13 +353,13 @@ def test_to_honeybee():
     """Test the to_honeybee method."""
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('Office_Floor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
 
     hb_model = building.to_honeybee(False, 0.01)
     assert isinstance(hb_model, Model)
@@ -374,13 +375,13 @@ def test_to_honeybee():
     assert isinstance(hb_model.rooms[0][1].boundary_condition, Outdoors)
     assert isinstance(hb_model.rooms[0][2].boundary_condition, Surface)
     assert hb_model.rooms[0][2].boundary_condition.boundary_condition_object == \
-        hb_model.rooms[1][4].name
+        hb_model.rooms[1][4].identifier
     assert len(hb_model.rooms[0][1].apertures) == 1
     assert len(hb_model.rooms[0][2].apertures) == 0
 
-    assert hb_model.check_duplicate_room_names()
-    assert hb_model.check_duplicate_face_names()
-    assert hb_model.check_duplicate_sub_face_names()
+    assert hb_model.check_duplicate_room_identifiers()
+    assert hb_model.check_duplicate_face_identifiers()
+    assert hb_model.check_duplicate_sub_face_identifiers()
     assert hb_model.check_missing_adjacencies()
 
     hb_model = building.to_honeybee(True, 0.01)
@@ -388,9 +389,9 @@ def test_to_honeybee():
     for room in hb_model.rooms:
         assert room.multiplier == 4
 
-    assert hb_model.check_duplicate_room_names()
-    assert hb_model.check_duplicate_face_names()
-    assert hb_model.check_duplicate_sub_face_names()
+    assert hb_model.check_duplicate_room_identifiers()
+    assert hb_model.check_duplicate_face_identifiers()
+    assert hb_model.check_duplicate_sub_face_identifiers()
     assert hb_model.check_missing_adjacencies()
 
 
@@ -399,18 +400,18 @@ def test_buildings_to_honeybee():
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
     pts_3 = (Point3D(0, 20, 3), Point3D(20, 20, 3), Point3D(20, 30, 3), Point3D(0, 30, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    story_big = Story('Office Floor Big', [room2d_3])
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    story_big = Story('Office_Floor_Big', [room2d_3])
+    story = Story('Office_Floor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
     story_big.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_big.multiplier = 4
-    building_big = Building('Office Building Big', [story_big])
+    building_big = Building('Office_Building_Big', [story_big])
 
     hb_model = Building.buildings_to_honeybee([building, building_big], False, 0.01)
     assert isinstance(hb_model, Model)
@@ -432,18 +433,18 @@ def test_buildings_to_honeybee_self_shade():
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
     pts_3 = (Point3D(0, 20, 3), Point3D(20, 20, 3), Point3D(20, 30, 3), Point3D(0, 30, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    story_big = Story('Office Floor Big', [room2d_3])
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    story_big = Story('Office_Floor_Big', [room2d_3])
+    story = Story('Office_Floor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
     story_big.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_big.multiplier = 4
-    building_big = Building('Office Building Big', [story_big])
+    building_big = Building('Office_Building_Big', [story_big])
 
     hb_models = Building.buildings_to_honeybee_self_shade(
         [building, building_big], None, None, False, 0.01)
@@ -471,20 +472,20 @@ def test_to_dict():
     """Test the Building to_dict method."""
     pts_1 = (Point3D(0, 0, 2), Point3D(10, 0, 2), Point3D(10, 10, 2), Point3D(0, 10, 2))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 5)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 5)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('Office_Floor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.set_outdoor_shading_parameters(Overhang(1))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
     building.separate_top_bottom_floors()
 
     bd = building.to_dict()
     assert bd['type'] == 'Building'
-    assert bd['name'] == 'OfficeBuilding'
-    assert bd['display_name'] == 'Office Building'
+    assert bd['identifier'] == 'Office_Building'
+    assert bd['display_name'] == 'Office_Building'
     assert 'unique_stories' in bd
     assert len(bd['unique_stories']) == 3
     assert 'properties' in bd
@@ -495,14 +496,14 @@ def test_to_from_dict():
     """Test the to/from dict of Story objects."""
     pts_1 = (Point3D(0, 0, 2), Point3D(10, 0, 2), Point3D(10, 10, 2), Point3D(0, 10, 2))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 5)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 5)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('Office_Floor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.set_outdoor_shading_parameters(Overhang(1))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
     building.separate_top_bottom_floors()
 
     building_dict = building.to_dict()

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -14,11 +14,11 @@ def test_context_shade_init():
     """Test the initialization of ContextShade objects."""
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy = ContextShade('Tree Canopy', [tree_canopy_geo1, tree_canopy_geo2])
+    tree_canopy = ContextShade('Tree_Canopy', [tree_canopy_geo1, tree_canopy_geo2])
     str(tree_canopy)  # test the string representation
 
-    assert tree_canopy.name == 'TreeCanopy'
-    assert tree_canopy.display_name == 'Tree Canopy'
+    assert tree_canopy.identifier == 'Tree_Canopy'
+    assert tree_canopy.display_name == 'Tree_Canopy'
     assert len(tree_canopy) == len(tree_canopy.geometry) == 2
     for geo in tree_canopy:
         assert isinstance(geo, Face3D)
@@ -29,7 +29,7 @@ def test_context_shade_min_max():
     """Test the min and max properties of ContextShade objects."""
     awning_geo1 = Face3D.from_rectangle(6, 6, Plane(o=Point3D(5, -10, 6)))
     awning_geo2 = Face3D.from_rectangle(2, 2, Plane(o=Point3D(-5, -10, 3)))
-    awning_canopy = ContextShade('Awning Canopy', [awning_geo1, awning_geo2])
+    awning_canopy = ContextShade('Awning_Canopy', [awning_geo1, awning_geo2])
 
     assert awning_canopy.area == 40
     assert awning_canopy.min == Point2D(-5, -10)
@@ -40,7 +40,7 @@ def test_move():
     """Test the ContextShade move method."""
     pts_1 = (Point3D(0, 2, 3), Point3D(2, 2, 3), Point3D(2, 0, 3), Point3D(0, 0, 3))
     plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 0))
-    awning_canopy = ContextShade('Awning Canopy', [Face3D(pts_1, plane_1)])
+    awning_canopy = ContextShade('Awning_Canopy', [Face3D(pts_1, plane_1)])
 
     vec_1 = Vector3D(2, 2, 2)
     new_a = awning_canopy.duplicate()
@@ -56,7 +56,7 @@ def test_scale():
     """Test the ContextShade scale method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 0))
-    awning_canopy = ContextShade('Awning Canopy', [Face3D(pts, plane_1)])
+    awning_canopy = ContextShade('Awning_Canopy', [Face3D(pts, plane_1)])
 
     new_a = awning_canopy.duplicate()
     new_a.scale(2)
@@ -71,7 +71,7 @@ def test_rotate_xy():
     """Test the ContextShade rotate_xy method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    awning_canopy = ContextShade('Awning Canopy', [Face3D(pts, plane)])
+    awning_canopy = ContextShade('Awning_Canopy', [Face3D(pts, plane)])
     origin_1 = Point3D(1, 1, 0)
 
     test_1 = awning_canopy.duplicate()
@@ -88,7 +88,7 @@ def test_reflect():
     """Test the ContextShade reflect method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    awning_canopy = ContextShade('Awning Canopy', [Face3D(pts, plane)])
+    awning_canopy = ContextShade('Awning_Canopy', [Face3D(pts, plane)])
 
     origin_1 = Point3D(1, 0, 2)
     normal_1 = Vector3D(1, 0, 0)
@@ -108,14 +108,14 @@ def test_to_honeybee():
     """Test the to_honeybee method."""
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy = ContextShade('Tree Canopy', [tree_canopy_geo1, tree_canopy_geo2])
+    tree_canopy = ContextShade('Tree_Canopy', [tree_canopy_geo1, tree_canopy_geo2])
     hb_tree_canopies = tree_canopy.to_honeybee()
 
     assert len(hb_tree_canopies) == 2
     for shd in hb_tree_canopies:
         assert isinstance(shd, Shade)
-        assert shd.name.startswith('TreeCanopy')
-    assert hb_tree_canopies[0].name != hb_tree_canopies[1].name
+        assert shd.identifier.startswith('Tree_Canopy')
+    assert hb_tree_canopies[0].identifier != hb_tree_canopies[1].identifier
     assert tree_canopy.area == sum([shd.area for shd in hb_tree_canopies])
 
 
@@ -123,12 +123,12 @@ def test_to_dict():
     """Test the ContextShade to_dict method."""
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy = ContextShade('Tree Canopy', [tree_canopy_geo1, tree_canopy_geo2])
+    tree_canopy = ContextShade('Tree_Canopy', [tree_canopy_geo1, tree_canopy_geo2])
 
     sd = tree_canopy.to_dict()
     assert sd['type'] == 'ContextShade'
-    assert sd['name'] == 'TreeCanopy'
-    assert sd['display_name'] == 'Tree Canopy'
+    assert sd['identifier'] == 'Tree_Canopy'
+    assert sd['display_name'] == 'Tree_Canopy'
     assert len(sd['geometry']) == 2
 
 
@@ -136,7 +136,7 @@ def test_to_from_dict():
     """Test the to/from dict of ContextShade objects."""
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy = ContextShade('Tree Canopy', [tree_canopy_geo1, tree_canopy_geo2])
+    tree_canopy = ContextShade('Tree_Canopy', [tree_canopy_geo1, tree_canopy_geo2])
 
     context_dict = tree_canopy.to_dict()
     new_context = ContextShade.from_dict(context_dict)

--- a/tests/json/model_with_nulls.json
+++ b/tests/json/model_with_nulls.json
@@ -1,15 +1,15 @@
 {
   "units": "Meters",
-  "name": "Model_14e27252-22a3-4b51-b476-4e49634e3ef7",
+  "identifier": "Model_14e27252-22a3-4b51-b476-4e49634e3ef7",
   "buildings": [
     {
-      "name": "Building_59048489-606f-486e-819c-f3604a334bba",
+      "identifier": "Building_59048489-606f-486e-819c-f3604a334bba",
       "unique_stories": [
         {
-          "name": "Story_508f925a-c593-4128-a6f0-ce4b7962d7e7",
+          "identifier": "Story_508f925a-c593-4128-a6f0-ce4b7962d7e7",
           "room_2ds": [
             {
-              "name": "Room_31294ad6-26bd-4e5e-b6a3-3038586dc83a",
+              "identifier": "Room_31294ad6-26bd-4e5e-b6a3-3038586dc83a",
               "floor_boundary": [
                 [
                   22.89347610707884,
@@ -250,7 +250,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_cdd07fc6-a3c0-4be7-915f-a860a6979d26",
+              "identifier": "Room_cdd07fc6-a3c0-4be7-915f-a860a6979d26",
               "floor_boundary": [
                 [
                   32.758961671383304,
@@ -328,7 +328,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_0719dc34-9610-4926-aaac-cc3d03e1d44b",
+              "identifier": "Room_0719dc34-9610-4926-aaac-cc3d03e1d44b",
               "floor_boundary": [
                 [
                   32.758961671383311,
@@ -392,7 +392,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_a53a02ad-7d90-4729-9804-3db0f1617a21",
+              "identifier": "Room_a53a02ad-7d90-4729-9804-3db0f1617a21",
               "floor_boundary": [
                 [
                   33.0115863432995,
@@ -557,7 +557,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_ef6f1295-ebe9-44a2-b600-3d8edd7472ea",
+              "identifier": "Room_ef6f1295-ebe9-44a2-b600-3d8edd7472ea",
               "floor_boundary": [
                 [
                   43.1296965795197,
@@ -653,7 +653,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_8c1b0474-5910-4e80-b93c-29bf1e02a137",
+              "identifier": "Room_8c1b0474-5910-4e80-b93c-29bf1e02a137",
               "floor_boundary": [
                 [
                   22.89347610707885,
@@ -737,10 +737,10 @@
           "multiplier": 1
         },
         {
-          "name": "Story_dfdaf24d-239d-48dc-8d06-8dcf925fe2c5",
+          "identifier": "Story_dfdaf24d-239d-48dc-8d06-8dcf925fe2c5",
           "room_2ds": [
             {
-              "name": "Room_5846931a-4832-4551-9d0a-1f75ef6bb4b5",
+              "identifier": "Room_5846931a-4832-4551-9d0a-1f75ef6bb4b5",
               "floor_boundary": [
                 [
                   3.4840272881812209,
@@ -851,7 +851,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_7b85a04e-bf60-4a53-a8a1-a083bf153211",
+              "identifier": "Room_7b85a04e-bf60-4a53-a8a1-a083bf153211",
               "floor_boundary": [
                 [
                   -4.5212220556508589,
@@ -927,7 +927,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_e9f3ea3f-9f38-489c-ad6a-c95892942e88",
+              "identifier": "Room_e9f3ea3f-9f38-489c-ad6a-c95892942e88",
               "floor_boundary": [
                 [
                   3.484027288181188,
@@ -1044,7 +1044,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_ffeb608c-14f1-4502-b85a-4133a6e3ef4f",
+              "identifier": "Room_ffeb608c-14f1-4502-b85a-4133a6e3ef4f",
               "floor_boundary": [
                 [
                   14.782301833712436,
@@ -1105,7 +1105,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_8aac3fce-03e0-4307-becc-6f45343ccae2",
+              "identifier": "Room_8aac3fce-03e0-4307-becc-6f45343ccae2",
               "floor_boundary": [
                 [
                   13.523397366921365,
@@ -1165,7 +1165,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_04f41209-05ed-4580-8ccb-011a0bdba133",
+              "identifier": "Room_04f41209-05ed-4580-8ccb-011a0bdba133",
               "floor_boundary": [
                 [
                   32.75896167138329,
@@ -1278,7 +1278,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_d9c41d2c-8d1f-4f53-94ff-29e56c4a2301",
+              "identifier": "Room_d9c41d2c-8d1f-4f53-94ff-29e56c4a2301",
               "floor_boundary": [
                 [
                   32.758961671383311,
@@ -1408,7 +1408,7 @@
               "shading_parameters": null
             },
             {
-              "name": "Room_c71ae0c1-83f2-4f8c-852d-4d047c1d84d3",
+              "identifier": "Room_c71ae0c1-83f2-4f8c-852d-4d047c1d84d3",
               "floor_boundary": [
                 [
                   21.708764820989828,

--- a/tests/json/sample_revit_model.json
+++ b/tests/json/sample_revit_model.json
@@ -1,6 +1,6 @@
 {
     "type": "Model",
-    "name": "SampleModel",
+    "identifier": "SampleModel",
     "display_name": "Sample Model",
     "properties": {
         "type": "ModelProperties"
@@ -8,17 +8,17 @@
     "buildings": [
         {
             "type": "Building",
-            "name": "SampleBuilding",
+            "identifier": "SampleBuilding",
             "display_name": "Sample Building",
             "unique_stories": [
                 {
                     "type": "Story",
-                    "name": "GroundFloor",
+                    "identifier": "GroundFloor",
                     "display_name": "Ground Floor",
                     "room_2ds": [
                         {
                             "type": "Room2D",
-                            "name": "KitchenDining",
+                            "identifier": "KitchenDining",
                             "display_name": "Kitchen & Dining 101",
                             "properties": {
                                 "type": "Room2DPropertiesAbridged"
@@ -178,7 +178,7 @@
                         },
                         {
                             "type": "Room2D",
-                            "name": "Laundry",
+                            "identifier": "Laundry",
                             "display_name": "Laundry 104",
                             "properties": {
                                 "type": "Room2DPropertiesAbridged"
@@ -237,7 +237,7 @@
                         },
                         {
                             "type": "Room2D",
-                            "name": "Bath",
+                            "identifier": "Bath",
                             "display_name": "Bath 103",
                             "properties": {
                                 "type": "Room2DPropertiesAbridged"
@@ -282,7 +282,7 @@
                         },
                         {
                             "type": "Room2D",
-                            "name": "Hall",
+                            "identifier": "Hall",
                             "display_name": "Hall 105",
                             "properties": {
                                 "type": "Room2DPropertiesAbridged"
@@ -397,7 +397,7 @@
                         },
                         {
                             "type": "Room2D",
-                            "name": "Living",
+                            "identifier": "Living",
                             "display_name": "Living 106",
                             "properties": {
                                 "type": "Room2DPropertiesAbridged"
@@ -470,7 +470,7 @@
                         },
                         {
                             "type": "Room2D",
-                            "name": "Mech.",
+                            "identifier": "Mech.",
                             "display_name": "Mech. 102",
                             "properties": {
                                 "type": "Room2DPropertiesAbridged"

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -29,25 +29,25 @@ def test_model_init():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('Office_Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('Office_Building', [story])
 
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy = ContextShade('Tree Canopy', [tree_canopy_geo1, tree_canopy_geo2])
+    tree_canopy = ContextShade('Tree_Canopy', [tree_canopy_geo1, tree_canopy_geo2])
 
-    model = Model('New Development', [building], [tree_canopy])
+    model = Model('New_Development', [building], [tree_canopy])
     str(model)  # test the string representation of the object
 
-    assert model.name == 'NewDevelopment'
-    assert model.display_name == 'New Development'
+    assert model.identifier == 'New_Development'
+    assert model.display_name == 'New_Development'
     assert model.north_angle == 0
     assert model.north_vector == Vector2D(0, 1)
     assert model.units == 'Meters'
@@ -68,20 +68,20 @@ def test_model_properties_setability():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('OfficeBuilding', [story])
 
-    model = Model('New Development', [building])
+    model = Model('NewDevelopment', [building])
 
-    model.name = 'TestBuilding'
-    assert model.name == 'TestBuilding'
+    model.display_name = 'TestBuilding'
+    assert model.display_name == 'TestBuilding'
     model.north_angle = 20
     assert model.north_angle == 20
     model.units = 'Feet'
@@ -93,32 +93,32 @@ def test_model_properties_setability():
 
 
 def test_model_add_objects():
-    """Test the addition of objects to a Model and getting objects by name."""
+    """Test the addition of objects to a Model and getting objects by identifier."""
     pts_1 = (Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(10, 10, 3), Point3D(10, 0, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 20, 3), Point3D(0, 30, 3), Point3D(10, 30, 3), Point3D(10, 20, 3))
     pts_4 = (Point3D(10, 20, 3), Point3D(10, 30, 3), Point3D(20, 30, 3), Point3D(20, 20, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story_1 = Story('Office Floor 1', [room2d_1, room2d_2])
-    story_2 = Story('Office Floor 2', [room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story_1 = Story('OfficeFloor1', [room2d_1, room2d_2])
+    story_2 = Story('OfficeFloor2', [room2d_3, room2d_4])
     story_1.solve_room_2d_adjacency(0.01)
     story_1.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_1.multiplier = 4
     story_2.solve_room_2d_adjacency(0.01)
     story_2.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_2.multiplier = 2
-    building_1 = Building('Office Building 1', [story_1])
-    building_2 = Building('Office Building 2', [story_2])
+    building_1 = Building('OfficeBuilding1', [story_1])
+    building_2 = Building('OfficeBuilding2', [story_2])
 
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy_1 = ContextShade('Tree Canopy 1', [tree_canopy_geo1])
-    tree_canopy_2 = ContextShade('Tree Canopy 2', [tree_canopy_geo2])
+    tree_canopy_1 = ContextShade('TreeCanopy1', [tree_canopy_geo1])
+    tree_canopy_2 = ContextShade('TreeCanopy2', [tree_canopy_geo2])
 
-    model = Model('New Development', [building_1], [tree_canopy_1], 15)
+    model = Model('NewDevelopment', [building_1], [tree_canopy_1], 15)
     assert len(model.buildings) == 1
     assert len(model.context_shades) == 1
     assert model.north_angle == 15
@@ -131,12 +131,12 @@ def test_model_add_objects():
     model.add_context_shade(tree_canopy_2)
     assert len(model.context_shades) == 2
 
-    assert len(model.buildings_by_name(['OfficeBuilding1'])) == 1
+    assert len(model.buildings_by_identifier(['OfficeBuilding1'])) == 1
     with pytest.raises(ValueError):
-        model.buildings_by_name(['NotABuilding'])
-    assert len(model.context_shade_by_name(['TreeCanopy1'])) == 1
+        model.buildings_by_identifier(['NotABuilding'])
+    assert len(model.context_shade_by_identifier(['TreeCanopy1'])) == 1
     with pytest.raises(ValueError):
-        model.context_shade_by_name(['NotAShade'])
+        model.context_shade_by_identifier(['NotAShade'])
 
 
 def test_model_add_model():
@@ -145,28 +145,28 @@ def test_model_add_model():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 20, 3), Point3D(0, 30, 3), Point3D(10, 30, 3), Point3D(10, 20, 3))
     pts_4 = (Point3D(10, 20, 3), Point3D(10, 30, 3), Point3D(20, 30, 3), Point3D(20, 20, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story_1 = Story('Office Floor 1', [room2d_1, room2d_2])
-    story_2 = Story('Office Floor 2', [room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story_1 = Story('OfficeFloor1', [room2d_1, room2d_2])
+    story_2 = Story('OfficeFloor2', [room2d_3, room2d_4])
     story_1.solve_room_2d_adjacency(0.01)
     story_1.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_1.multiplier = 4
     story_2.solve_room_2d_adjacency(0.01)
     story_2.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_2.multiplier = 2
-    building_1 = Building('Office Building 1', [story_1])
-    building_2 = Building('Office Building 2', [story_2])
+    building_1 = Building('OfficeBuilding1', [story_1])
+    building_2 = Building('OfficeBuilding2', [story_2])
 
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy_1 = ContextShade('Tree Canopy 1', [tree_canopy_geo1])
-    tree_canopy_2 = ContextShade('Tree Canopy 2', [tree_canopy_geo2])
+    tree_canopy_1 = ContextShade('TreeCanopy1', [tree_canopy_geo1])
+    tree_canopy_2 = ContextShade('TreeCanopy2', [tree_canopy_geo2])
 
-    model_1 = Model('New Development 1', [building_1], [tree_canopy_1], 15)
-    model_2 = Model('New Development 2', [building_2], [tree_canopy_2], 15)
+    model_1 = Model('NewDevelopment1', [building_1], [tree_canopy_1], 15)
+    model_2 = Model('NewDevelopment2', [building_2], [tree_canopy_2], 15)
 
     assert len(model_1.buildings) == 1
     assert len(model_1.context_shades) == 1
@@ -188,18 +188,18 @@ def test_move():
     """Test the Model move method."""
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('OfficeBuilding', [story])
     awning_geo1 = Face3D.from_rectangle(6, 6, Plane(o=Point3D(5, -10, 6)))
     awning_geo2 = Face3D.from_rectangle(2, 2, Plane(o=Point3D(-5, -10, 3)))
-    awning_canopy_1 = ContextShade('Awning Canopy 1', [awning_geo1])
-    awning_canopy_2 = ContextShade('Awning Canopy 2', [awning_geo2])
+    awning_canopy_1 = ContextShade('AwningCanopy1', [awning_geo1])
+    awning_canopy_2 = ContextShade('AwningCanopy2', [awning_geo2])
 
-    model = Model('New Development', [building], [awning_canopy_1, awning_canopy_2])
+    model = Model('NewDevelopment', [building], [awning_canopy_1, awning_canopy_2])
 
     vec_1 = Vector3D(2, 2, 2)
     new_m = model.duplicate()
@@ -222,18 +222,18 @@ def test_scale():
     """Test the Model scale method."""
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('OfficeBuilding', [story])
     awning_geo1 = Face3D.from_rectangle(6, 6, Plane(o=Point3D(5, -10, 6)))
     awning_geo2 = Face3D.from_rectangle(2, 2, Plane(o=Point3D(-5, -10, 3)))
-    awning_canopy_1 = ContextShade('Awning Canopy 1', [awning_geo1])
-    awning_canopy_2 = ContextShade('Awning Canopy 2', [awning_geo2])
+    awning_canopy_1 = ContextShade('AwningCanopy1', [awning_geo1])
+    awning_canopy_2 = ContextShade('AwningCanopy2', [awning_geo2])
 
-    model = Model('New Development', [building], [awning_canopy_1, awning_canopy_2])
+    model = Model('NewDevelopment', [building], [awning_canopy_1, awning_canopy_2])
 
     new_m = model.duplicate()
     new_m.scale(2)
@@ -255,13 +255,13 @@ def test_convert_to_units():
     """Test the Model convert_to_units method."""
     pts_1 = (Point3D(0, 0), Point3D(120, 0), Point3D(120, 120), Point3D(0, 120))
     pts_2 = (Point3D(120, 0), Point3D(240, 0), Point3D(240, 120), Point3D(120, 120))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 96)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 96)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 96)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 96)
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.multiplier = 4
-    building = Building('Office Building', [story])
-    model = Model('New Development', [building], units='Inches')
+    building = Building('OfficeBuilding', [story])
+    model = Model('NewDevelopment', [building], units='Inches')
 
     inches_conversion = hb_model.Model.conversion_factor_to_meters('Inches')
     model.convert_to_units('Meters')
@@ -275,15 +275,15 @@ def test_rotate_xy():
     """Test the Model rotate_xy method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    room = Room2D('Square Shoebox', Face3D(pts, plane), 3)
-    story = Story('Office Floor', [room])
+    room = Room2D('SquareShoebox', Face3D(pts, plane), 3)
+    story = Story('OfficeFloor', [room])
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('OfficeBuilding', [story])
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 0))
-    awning_canopy = ContextShade('Awning Canopy', [Face3D(pts, plane_1)])
+    awning_canopy = ContextShade('AwningCanopy', [Face3D(pts, plane_1)])
 
-    model = Model('New Development', [building], [awning_canopy])
+    model = Model('NewDevelopment', [building], [awning_canopy])
 
     origin_1 = Point3D(1, 1, 0)
     test_1 = model.duplicate()
@@ -307,15 +307,15 @@ def test_reflect():
     """Test the Model reflect method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    room = Room2D('Square Shoebox', Face3D(pts, plane), 3)
-    story = Story('Office Floor', [room])
+    room = Room2D('SquareShoebox', Face3D(pts, plane), 3)
+    story = Story('OfficeFloor', [room])
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('OfficeBuilding', [story])
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    awning_canopy = ContextShade('Awning Canopy', [Face3D(pts, plane)])
+    awning_canopy = ContextShade('AwningCanopy', [Face3D(pts, plane)])
 
-    model = Model('New Development', [building], [awning_canopy])
+    model = Model('NewDevelopment', [building], [awning_canopy])
 
     origin_1 = Point3D(1, 0, 2)
     normal_1 = Vector3D(1, 0, 0)
@@ -338,46 +338,46 @@ def test_reflect():
     assert test_1.context_shades[0][0][1].z == pytest.approx(2, rel=1e-3)
 
 
-def test_check_duplicate_names():
-    """Test check_duplicate_building_names and check_duplicate_context_shade_names."""
+def test_check_duplicate_identifiers():
+    """Test check_duplicate_building_identifiers."""
     pts_1 = (Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(10, 10, 3), Point3D(10, 0, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 20, 3), Point3D(0, 30, 3), Point3D(10, 30, 3), Point3D(10, 20, 3))
     pts_4 = (Point3D(10, 20, 3), Point3D(10, 30, 3), Point3D(20, 30, 3), Point3D(20, 20, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story_1 = Story('Office Floor 1', [room2d_1, room2d_2])
-    story_2 = Story('Office Floor 2', [room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story_1 = Story('OfficeFloor1', [room2d_1, room2d_2])
+    story_2 = Story('OfficeFloor2', [room2d_3, room2d_4])
     story_1.solve_room_2d_adjacency(0.01)
     story_1.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_1.multiplier = 4
     story_2.solve_room_2d_adjacency(0.01)
     story_2.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_2.multiplier = 2
-    building_1 = Building('Office Building', [story_1])
-    building_2 = Building('Office Building', [story_2])
+    building_1 = Building('OfficeBuilding', [story_1])
+    building_2 = Building('OfficeBuilding', [story_2])
 
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy_1 = ContextShade('Tree Canopy', [tree_canopy_geo1])
-    tree_canopy_2 = ContextShade('Tree Canopy', [tree_canopy_geo2])
+    tree_canopy_1 = ContextShade('TreeCanopy', [tree_canopy_geo1])
+    tree_canopy_2 = ContextShade('TreeCanopy', [tree_canopy_geo2])
 
-    model_1 = Model('New Development 1', [building_1], [tree_canopy_1], 15)
-    model_2 = Model('New Development 2', [building_2], [tree_canopy_2], 15)
+    model_1 = Model('NewDevelopment1', [building_1], [tree_canopy_1], 15)
+    model_2 = Model('NewDevelopment2', [building_2], [tree_canopy_2], 15)
 
-    assert model_1.check_duplicate_building_names(False)
-    assert model_1.check_duplicate_context_shade_names(False)
+    assert model_1.check_duplicate_building_identifiers(False)
+    assert model_1.check_duplicate_context_shade_identifiers(False)
     
     model_1.add_model(model_2)
     
-    assert not model_1.check_duplicate_building_names(False)
+    assert not model_1.check_duplicate_building_identifiers(False)
     with pytest.raises(ValueError):
-        model_1.check_duplicate_building_names(True)
-    assert not model_1.check_duplicate_context_shade_names(False)
+        model_1.check_duplicate_building_identifiers(True)
+    assert not model_1.check_duplicate_context_shade_identifiers(False)
     with pytest.raises(ValueError):
-        model_1.check_duplicate_context_shade_names(True)
+        model_1.check_duplicate_context_shade_identifiers(True)
 
 
 def test_to_honeybee():
@@ -385,24 +385,24 @@ def test_to_honeybee():
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
     pts_3 = (Point3D(0, 20, 3), Point3D(20, 20, 3), Point3D(20, 30, 3), Point3D(0, 30, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    story_big = Story('Office Floor Big', [room2d_3])
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    story_big = Story('OfficeFloorBig', [room2d_3])
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('OfficeBuilding', [story])
     story_big.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_big.multiplier = 4
-    building_big = Building('Office Building Big', [story_big])
+    building_big = Building('OfficeBuildingBig', [story_big])
     
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy = ContextShade('Tree Canopy', [tree_canopy_geo1, tree_canopy_geo2])
+    tree_canopy = ContextShade('TreeCanopy', [tree_canopy_geo1, tree_canopy_geo2])
 
-    model = Model('New Development', [building, building_big], [tree_canopy])
+    model = Model('NewDevelopment', [building, building_big], [tree_canopy])
 
     hb_models = model.to_honeybee('District', None, False, 0.01)
     assert len(hb_models) == 1
@@ -420,24 +420,24 @@ def test_to_honeybee_multiple_models():
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
     pts_3 = (Point3D(0, 20, 3), Point3D(20, 20, 3), Point3D(20, 30, 3), Point3D(0, 30, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    story_big = Story('Office Floor Big', [room2d_3])
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    story_big = Story('OfficeFloorBig', [room2d_3])
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('OfficeBuilding', [story])
     story_big.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_big.multiplier = 4
-    building_big = Building('Office Building Big', [story_big])
+    building_big = Building('OfficeBuildingBig', [story_big])
 
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy = ContextShade('Tree Canopy', [tree_canopy_geo1, tree_canopy_geo2])
+    tree_canopy = ContextShade('TreeCanopy', [tree_canopy_geo1, tree_canopy_geo2])
 
-    model = Model('New Development', [building, building_big], [tree_canopy])
+    model = Model('NewDevelopment', [building, building_big], [tree_canopy])
 
     hb_models = model.to_honeybee('Building', 10, False, 0.01)
     assert len(hb_models) == 2
@@ -458,29 +458,29 @@ def test_to_dict():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('OfficeBuilding', [story])
 
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy = ContextShade('Tree Canopy', [tree_canopy_geo1, tree_canopy_geo2])
+    tree_canopy = ContextShade('TreeCanopy', [tree_canopy_geo1, tree_canopy_geo2])
 
-    model = Model('New Development', [building], [tree_canopy])
+    model = Model('NewDevelopment', [building], [tree_canopy])
     model.north_angle = 15
     model.tolerance = 0.01
     model.angle_tolerance = 1
 
     model_dict = model.to_dict()
     assert model_dict['type'] == 'Model'
-    assert model_dict['name'] == 'NewDevelopment'
-    assert model_dict['display_name'] == 'New Development'
+    assert model_dict['identifier'] == 'NewDevelopment'
+    assert model_dict['display_name'] == 'NewDevelopment'
     assert 'buildings' in model_dict
     assert len(model_dict['buildings']) == 1
     assert 'context_shades' in model_dict
@@ -501,21 +501,21 @@ def test_to_from_dict_methods():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 4
-    building = Building('Office Building', [story])
+    building = Building('OfficeBuilding', [story])
 
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy = ContextShade('Tree Canopy', [tree_canopy_geo1, tree_canopy_geo2])
+    tree_canopy = ContextShade('TreeCanopy', [tree_canopy_geo1, tree_canopy_geo2])
 
-    model = Model('New Development', [building], [tree_canopy])
+    model = Model('NewDevelopment', [building], [tree_canopy])
     model.north_angle = 15
 
     model_dict = model.to_dict()
@@ -538,41 +538,41 @@ def test_to_geojson():
     pts_1 = (Point3D(50, 50, 3), Point3D(60, 50, 3), Point3D(60, 60, 3), Point3D(50, 60, 3))
     pts_2 = (Point3D(60, 50, 3), Point3D(70, 50, 3), Point3D(70, 60, 3), Point3D(60, 60, 3))
     pts_3 = (Point3D(50, 70, 3), Point3D(70, 70, 3), Point3D(70, 80, 3), Point3D(50, 80, 3))
-    room2d_1 = Room2D('Residence 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Residence 2', Face3D(pts_2), 3)
+    room2d_1 = Room2D('Residence1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Residence2', Face3D(pts_2), 3)
     room2d_3 = Room2D('Retail', Face3D(pts_3), 3)
-    story_big = Story('Retail Floor', [room2d_3])
-    story = Story('Residence Floor', [room2d_1, room2d_2])
+    story_big = Story('RetailFloor', [room2d_3])
+    story = Story('ResidenceFloor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 3
-    building = Building('Residence Building', [story])
+    building = Building('ResidenceBuilding', [story])
     story_big.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story_big.multiplier = 1
-    building_big = Building('Retail Building Big', [story_big])
+    building_big = Building('RetailBuildingBig', [story_big])
 
     pts_1 = (Point3D(0, 0, 3), Point3D(0, 5, 3), Point3D(15, 5, 3), Point3D(15, 0, 3))
     pts_2 = (Point3D(15, 0, 3), Point3D(15, 15, 3), Point3D(20, 15, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 5, 3), Point3D(0, 20, 3), Point3D(5, 20, 3), Point3D(5, 5, 3))
     pts_4 = (Point3D(5, 15, 3), Point3D(5, 20, 3), Point3D(20, 20, 3), Point3D(20, 15, 3))
     pts_5 = (Point3D(-5, -5, 3), Point3D(-10, -5, 3), Point3D(-10, -10, 3), Point3D(-5, -10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    room2d_5 = Room2D('Office 5', Face3D(pts_5), 3)
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    room2d_5 = Room2D('Office5', Face3D(pts_5), 3)
     int_rms = Room2D.intersect_adjacency(
         [room2d_1, room2d_2, room2d_3, room2d_4, room2d_5], 0.01)
-    story = Story('Office Floor', int_rms)
+    story = Story('OfficeFloor', int_rms)
     story.rotate_xy(5, Point3D(0, 0, 0))
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.multiplier = 5
-    building_mult = Building('Office Building', [story])
+    building_mult = Building('OfficeBuilding', [story])
 
     tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
     tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
-    tree_canopy = ContextShade('Tree Canopy', [tree_canopy_geo1, tree_canopy_geo2])
+    tree_canopy = ContextShade('TreeCanopy', [tree_canopy_geo1, tree_canopy_geo2])
 
     model = Model('TestGeoJSON', [building, building_big, building_mult], [tree_canopy])
 
@@ -580,6 +580,6 @@ def test_to_geojson():
     geojson_folder = './tests/geojson/'
     model.to_geojson(location, folder=geojson_folder)
 
-    geo_fp = os.path.join(geojson_folder, model.name, '{}.geojson'.format(model.name))
+    geo_fp = os.path.join(geojson_folder, model.identifier, '{}.geojson'.format(model.identifier))
     assert os.path.isfile(geo_fp)
-    nukedir(os.path.join(geojson_folder, model.name), True)
+    nukedir(os.path.join(geojson_folder, model.identifier), True)

--- a/tests/room2d_test.py
+++ b/tests/room2d_test.py
@@ -22,11 +22,11 @@ def test_room2d_init():
     """Test the initalization of Room2D objects and basic properties."""
     pts = (Point3D(1, 1, 2), Point3D(1, 2, 2), Point3D(2, 2, 2), Point3D(2, 1, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    room2d = Room2D('Zone: CLOSET [920980]', Face3D(pts, plane), 3)
+    room2d = Room2D('ZoneCLOSET920980', Face3D(pts, plane), 3)
     str(room2d)  # test the string representation
 
-    assert room2d.name == 'ZoneCLOSET920980'
-    assert room2d.display_name == 'Zone: CLOSET [920980]'
+    assert room2d.identifier == 'ZoneCLOSET920980'
+    assert room2d.display_name == 'ZoneCLOSET920980'
     assert isinstance(room2d.floor_geometry, Face3D)
     assert len(room2d.floor_geometry.vertices) == 4
     assert room2d.floor_geometry.vertices == tuple(reversed(pts))
@@ -60,7 +60,7 @@ def test_room2d_init_with_windows():
     boundarycs = (bcs.outdoors, bcs.ground, bcs.outdoors, bcs.ground)
     window = (ashrae_base, None, ashrae_base, None)
     shading = (overhang, None, None, None)
-    room2d = Room2D('Square Shoebox', Face3D(pts), 3, boundarycs, window, shading)
+    room2d = Room2D('SquareShoebox', Face3D(pts), 3, boundarycs, window, shading)
 
     assert len(room2d.floor_geometry.vertices) == 4
     assert room2d.floor_geometry.vertices == tuple(pts)
@@ -86,7 +86,7 @@ def test_room_init_with_hole():
     bound_pts = [Point3D(0, 0), Point3D(3, 0), Point3D(3, 3), Point3D(0, 3)]
     hole_pts = [Point3D(1, 1, 0), Point3D(2, 1, 0), Point3D(2, 2, 0), Point3D(1, 2, 0)]
     face = Face3D(bound_pts, None, [hole_pts])
-    room2d = Room2D('Donut Room', face, 3)
+    room2d = Room2D('DonutRoom', face, 3)
 
     assert len(room2d.floor_geometry.vertices) == 10
     assert len(room2d) == 8
@@ -111,30 +111,30 @@ def test_room2d_init_invalid():
     boundarycs = [bcs.outdoors, bcs.ground, bcs.outdoors, bcs.ground]
     window = [ashrae_base, None, ashrae_base, None]
     shading = [overhang, None, None, None]
-    Room2D('Square Shoebox', Face3D(pts), 3, boundarycs, window, shading)
+    Room2D('SquareShoebox', Face3D(pts), 3, boundarycs, window, shading)
 
     old_bc = boundarycs.pop(-1)
     with pytest.raises(AssertionError):
-        Room2D('Square Shoebox', Face3D(pts), 3, boundarycs, window, shading)
+        Room2D('SquareShoebox', Face3D(pts), 3, boundarycs, window, shading)
     boundarycs.append(old_bc)
 
     old_glz = window.pop(-1)
     with pytest.raises(AssertionError):
-        Room2D('Square Shoebox', Face3D(pts), 3, boundarycs, window, shading)
+        Room2D('SquareShoebox', Face3D(pts), 3, boundarycs, window, shading)
     window.append(old_glz)
 
     old_shd = shading.pop(-1)
     with pytest.raises(AssertionError):
-        Room2D('Square Shoebox', Face3D(pts), 3, boundarycs, window, shading)
+        Room2D('SquareShoebox', Face3D(pts), 3, boundarycs, window, shading)
     shading.append(old_shd)
 
     new_bcs = [bcs.ground, bcs.outdoors, bcs.outdoors, bcs.ground]
     with pytest.raises(AssertionError):
-        Room2D('Square Shoebox', Face3D(pts), 3, new_bcs, window, shading)
+        Room2D('SquareShoebox', Face3D(pts), 3, new_bcs, window, shading)
 
     new_glz = [None, ashrae_base, ashrae_base, None]
     with pytest.raises(AssertionError):
-        Room2D('Square Shoebox', Face3D(pts), 3, boundarycs, new_glz, shading)
+        Room2D('SquareShoebox', Face3D(pts), 3, boundarycs, new_glz, shading)
 
 
 def test_room2d_init_clockwise():
@@ -179,7 +179,7 @@ def test_room2d_init_from_polygon():
     boundarycs = (bcs.outdoors, bcs.ground, bcs.outdoors, bcs.ground)
     window = (ashrae_base, None, ashrae_base, None)
     shading = (overhang, None, None, None)
-    room2d = Room2D.from_polygon('Square Shoebox', polygon, 3, 3,
+    room2d = Room2D.from_polygon('SquareShoebox', polygon, 3, 3,
                                  boundarycs, window, shading)
 
     assert len(room2d.floor_geometry.vertices) == 4
@@ -210,7 +210,7 @@ def test_room2d_init_from_polygon_clockwise():
     boundarycs = (bcs.outdoors, bcs.outdoors, bcs.ground, bcs.ground)
     window = (ashrae_base, ashrae_base, None, None)
     shading = (overhang, None, None, None)
-    room2d = Room2D.from_polygon('Square Shoebox', polygon, 3, 3,
+    room2d = Room2D.from_polygon('SquareShoebox', polygon, 3, 3,
                                  boundarycs, window, shading)
 
     assert room2d.floor_geometry.boundary == tuple(reversed(pts_3d))
@@ -227,7 +227,7 @@ def test_room2d_init_from_vertices():
     boundarycs = (bcs.outdoors, bcs.ground, bcs.outdoors, bcs.ground)
     window = (ashrae_base, None, ashrae_base, None)
     shading = (overhang, None, None, None)
-    room2d = Room2D.from_vertices('Square Shoebox', pts, 3, 3,
+    room2d = Room2D.from_vertices('SquareShoebox', pts, 3, 3,
                                   boundarycs, window, shading)
 
     assert len(room2d.floor_geometry.vertices) == 4
@@ -252,7 +252,7 @@ def test_room2d_segment_orientations():
     """Test the Room2D segment_orientations method."""
     pts = (Point3D(1, 1, 2), Point3D(1, 2, 2), Point3D(2, 2, 2), Point3D(2, 1, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    room2d = Room2D('Zone: CLOSET [920980]', Face3D(pts, plane), 3)
+    room2d = Room2D('ZoneCLOSET920980', Face3D(pts, plane), 3)
 
     assert room2d.segment_normals[0] == Vector2D(1, 0)
     assert room2d.segment_normals[1] == Vector2D(0, 1)
@@ -270,7 +270,7 @@ def test_room2d_set_outdoor_window_shading_parameters():
     """Test the Room2D set_outdoor_window_parameters method."""
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     boundarycs = (bcs.outdoors, bcs.ground, bcs.outdoors, bcs.ground)
-    room2d = Room2D('Square Shoebox', Face3D(pts), 3, boundarycs)
+    room2d = Room2D('SquareShoebox', Face3D(pts), 3, boundarycs)
     ashrae_base = SimpleWindowRatio(0.4)
     overhang = Overhang(1)
     room2d.set_outdoor_window_parameters(ashrae_base)
@@ -298,7 +298,7 @@ def test_room2d_set_outdoor_window_shading_parameters():
 def test_generate_grid():
     """Test the generate_grid method."""
     pts = (Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 10, 3), Point3D(0, 10, 3))
-    room = Room2D('Square Shoebox', Face3D(pts), 3)
+    room = Room2D('SquareShoebox', Face3D(pts), 3)
     mesh_grid = room.generate_grid(1)
     assert len(mesh_grid.faces) == 50
     mesh_grid = room.generate_grid(0.5)
@@ -308,7 +308,7 @@ def test_generate_grid():
 def test_room2d_set_boundary_condition():
     """Test the Room2D set_boundary_condition method."""
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
-    room2d = Room2D('Square Shoebox', Face3D(pts), 3)
+    room2d = Room2D('SquareShoebox', Face3D(pts), 3)
     room2d.set_boundary_condition(1, bcs.ground)
     room2d.set_boundary_condition(3, bcs.ground)
 
@@ -320,7 +320,7 @@ def test_move():
     """Test the Room2D move method."""
     pts_1 = (Point3D(0, 2, 0), Point3D(2, 2, 0), Point3D(2, 0, 0), Point3D(0, 0, 0))
     plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 0))
-    room = Room2D('Square Shoebox', Face3D(pts_1, plane_1), 3)
+    room = Room2D('SquareShoebox', Face3D(pts_1, plane_1), 3)
 
     vec_1 = Vector3D(2, 2, 2)
     new_r = room.duplicate()
@@ -337,7 +337,7 @@ def test_scale():
     """Test the Room2D scale method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 0))
-    room = Room2D('Square Shoebox', Face3D(pts, plane_1), 3)
+    room = Room2D('SquareShoebox', Face3D(pts, plane_1), 3)
     room.set_outdoor_window_parameters(SingleWindow(1, 1, 1))
     room.set_outdoor_shading_parameters(Overhang(1))
 
@@ -359,7 +359,7 @@ def test_rotate_xy():
     """Test the Room2D rotate_xy method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    room = Room2D('Square Shoebox', Face3D(pts, plane), 3)
+    room = Room2D('SquareShoebox', Face3D(pts, plane), 3)
     origin_1 = Point3D(1, 1, 0)
 
     test_1 = room.duplicate()
@@ -385,7 +385,7 @@ def test_reflect():
     """Test the Room2D reflect method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    room = Room2D('Square Shoebox', Face3D(pts, plane), 3)
+    room = Room2D('SquareShoebox', Face3D(pts, plane), 3)
 
     origin_1 = Point3D(1, 0, 2)
     origin_2 = Point3D(0, 0, 2)
@@ -427,7 +427,7 @@ def test_room2d_remove_colinear_vertices():
     """Test the Room2D remove_colinear_vertices method."""
     pts = (Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3),
            Point3D(0, 10, 3))
-    room2d = Room2D('Square Shoebox', Face3D(pts), 3)
+    room2d = Room2D('SquareShoebox', Face3D(pts), 3)
 
     assert len(room2d) == 5
     new_room = room2d.remove_colinear_vertices(0.01)
@@ -441,16 +441,16 @@ def test_room2d_solve_adjacency():
     """Test the Room2D solve_adjacency method."""
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Square Shoebox 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Square Shoebox 2', Face3D(pts_2), 3)
+    room2d_1 = Room2D('SquareShoebox1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('SquareShoebox2', Face3D(pts_2), 3)
     Room2D.solve_adjacency([room2d_1, room2d_2], 0.01)
 
     assert isinstance(room2d_1.boundary_conditions[1], Surface)
     assert isinstance(room2d_2.boundary_conditions[3], Surface)
     assert room2d_1.boundary_conditions[1].boundary_condition_object == \
-        '{}..Face4'.format(room2d_2.name)
+        '{}..Face4'.format(room2d_2.identifier)
     assert room2d_2.boundary_conditions[3].boundary_condition_object == \
-        '{}..Face2'.format(room2d_1.name)
+        '{}..Face2'.format(room2d_1.identifier)
 
 
 def test_solve_adjacency_aperture():
@@ -461,15 +461,15 @@ def test_solve_adjacency_aperture():
     window_1 = (None, ashrae_base, None, None)
     window_2 = (None, None, None, ashrae_base)
     window_3 = (None, None, None, None)
-    room2d_1 = Room2D('Square Shoebox 1', Face3D(pts_1), 3, None, window_1)
-    room2d_2 = Room2D('Square Shoebox 2', Face3D(pts_2), 3, None, window_2)
-    room2d_3 = Room2D('Square Shoebox 3', Face3D(pts_2), 3, None, window_3)
+    room2d_1 = Room2D('SquareShoebox1', Face3D(pts_1), 3, None, window_1)
+    room2d_2 = Room2D('SquareShoebox2', Face3D(pts_2), 3, None, window_2)
+    room2d_3 = Room2D('SquareShoebox3', Face3D(pts_2), 3, None, window_3)
     Room2D.solve_adjacency([room2d_1, room2d_2], 0.01)
 
     assert room2d_1.boundary_conditions[1].boundary_condition_object == \
-        '{}..Face4'.format(room2d_2.name)
+        '{}..Face4'.format(room2d_2.identifier)
     assert room2d_2.boundary_conditions[3].boundary_condition_object == \
-        '{}..Face2'.format(room2d_1.name)
+        '{}..Face2'.format(room2d_1.identifier)
 
     with pytest.raises(AssertionError):
         Room2D.solve_adjacency([room2d_1, room2d_3], 0.01)
@@ -479,8 +479,8 @@ def test_room2d_intersect_adjacency():
     """Test the Room2D intersect_adjacency method."""
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 5, 2), Point3D(20, 5, 2), Point3D(20, 15, 2), Point3D(10, 15, 2))
-    room2d_1 = Room2D('Square Shoebox 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Square Shoebox 2', Face3D(pts_2), 3)
+    room2d_1 = Room2D('SquareShoebox1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('SquareShoebox2', Face3D(pts_2), 3)
     room2d_1, room2d_2 = Room2D.intersect_adjacency([room2d_1, room2d_2], 0.01)
 
     assert len(room2d_1) == 5
@@ -491,9 +491,9 @@ def test_room2d_intersect_adjacency():
     assert isinstance(room2d_1.boundary_conditions[2], Surface)
     assert isinstance(room2d_2.boundary_conditions[4], Surface)
     assert room2d_1.boundary_conditions[2].boundary_condition_object == \
-        '{}..Face5'.format(room2d_2.name)
+        '{}..Face5'.format(room2d_2.identifier)
     assert room2d_2.boundary_conditions[4].boundary_condition_object == \
-        '{}..Face3'.format(room2d_1.name)
+        '{}..Face3'.format(room2d_1.identifier)
 
 
 def test_to_honeybee():
@@ -504,11 +504,11 @@ def test_to_honeybee():
     boundarycs = (bcs.outdoors, bcs.ground, bcs.outdoors, bcs.ground)
     window = (ashrae_base, None, ashrae_base, None)
     shading = (overhang, None, None, None)
-    room2d = Room2D('Zone: SHOE_BOX [920980]', Face3D(pts), 3, boundarycs, window, shading)
+    room2d = Room2D('ZoneSHOE_BOX920980', Face3D(pts), 3, boundarycs, window, shading)
     room = room2d.to_honeybee(1, 0.1)
 
-    assert room.name == 'ZoneSHOE_BOX920980'
-    assert room.display_name == 'Zone: SHOE_BOX [920980]'
+    assert room.identifier == 'ZoneSHOE_BOX920980'
+    assert room.display_name == 'ZoneSHOE_BOX920980'
     assert isinstance(room.geometry, Polyface3D)
     assert len(room.geometry.vertices) == 8
     assert len(room) == 6
@@ -533,12 +533,12 @@ def test_to_dict():
     boundarycs = (bcs.outdoors, bcs.ground, bcs.outdoors, bcs.ground)
     window = (ashrae_base, None, ashrae_base, None)
     shading = (overhang, None, None, None)
-    room = Room2D('Shoe Box Zone', Face3D(pts), 3, boundarycs, window, shading, True, False)
+    room = Room2D('ShoeBoxZone', Face3D(pts), 3, boundarycs, window, shading, True, False)
 
     rd = room.to_dict()
     assert rd['type'] == 'Room2D'
-    assert rd['name'] == 'ShoeBoxZone'
-    assert rd['display_name'] == 'Shoe Box Zone'
+    assert rd['identifier'] == 'ShoeBoxZone'
+    assert rd['display_name'] == 'ShoeBoxZone'
     assert 'floor_boundary' in rd
     assert len(rd['floor_boundary']) == 4
     assert 'floor_holes' not in rd
@@ -555,7 +555,7 @@ def test_to_dict():
     assert 'properties' in rd
     assert rd['properties']['type'] == 'Room2DProperties'
 
-    room_2 = Room2D('Shoe Box Zone', Face3D(pts), 3)
+    room_2 = Room2D('ShoeBoxZone', Face3D(pts), 3)
     rd = room_2.to_dict()
     assert 'boundary_conditions' in rd
     assert len(rd['boundary_conditions']) == 4
@@ -571,7 +571,7 @@ def test_to_from_dict():
     boundarycs = (bcs.outdoors, bcs.ground, bcs.outdoors, bcs.ground)
     window = (ashrae_base, None, ashrae_base, None)
     shading = (overhang, None, None, None)
-    room = Room2D('Shoe Box Zone', Face3D(pts), 3, boundarycs, window, shading, True)
+    room = Room2D('ShoeBoxZone', Face3D(pts), 3, boundarycs, window, shading, True)
 
     room_dict = room.to_dict()
     new_room = Room2D.from_dict(room_dict)

--- a/tests/shadingparameter_test.py
+++ b/tests/shadingparameter_test.py
@@ -56,7 +56,7 @@ def test_extruded_border_add_shading_to_face():
     height = 3
     width = 10
     seg = LineSegment3D.from_end_points(Point3D(0, 0, 2), Point3D(width, 0, 2))
-    face_1 = Face('test face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
+    face_1 = Face('test_face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
     face_2 = face_1.duplicate()
     face_2.apertures_by_ratio(0.4)
     simple_border.add_shading_to_face(face_1, 0.01)
@@ -116,7 +116,7 @@ def test_overhang_add_shading_to_face():
     height = 3
     width = 10
     seg = LineSegment3D.from_end_points(Point3D(0, 0, 2), Point3D(width, 0, 2))
-    face = Face('test face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
+    face = Face('test_face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
     simple_awning.add_shading_to_face(face, 0.01)
 
     assert len(face.outdoor_shades) == 1
@@ -175,7 +175,7 @@ def test_louvers_by_distance_add_shading_to_face():
     height = 3
     width = 10
     seg = LineSegment3D.from_end_points(Point3D(0, 0, 2), Point3D(width, 0, 2))
-    face = Face('test face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
+    face = Face('test_face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
     louvers.add_shading_to_face(face, 0.01)
 
     assert len(face.outdoor_shades) == 6
@@ -233,7 +233,7 @@ def test_louvers_by_count_add_shading_to_face():
     height = 3
     width = 10
     seg = LineSegment3D.from_end_points(Point3D(0, 0, 2), Point3D(width, 0, 2))
-    face = Face('test face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
+    face = Face('test_face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
 
     louvers.add_shading_to_face(face, 0.01)
 

--- a/tests/story_test.py
+++ b/tests/story_test.py
@@ -22,17 +22,17 @@ def test_story_init():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
     str(story)  # test the string representation
-    assert story.name == 'OfficeFloor'
-    assert story.display_name == 'Office Floor'
+    assert story.identifier == 'OfficeFloor'
+    assert story.display_name == 'OfficeFloor'
     assert len(story.room_2ds) == 4
     for room in story.room_2ds:
         assert isinstance(room, Room2D)
@@ -54,11 +54,11 @@ def test_story_floor_geometry():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2, room2d_3, room2d_4])
 
     floor_geo = story.floor_geometry(0.01)
     outline_segs = story.outline_segments(0.01)
@@ -75,24 +75,24 @@ def test_story_add_rooms():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('OfficeFloor', [room2d_1])
 
     assert story.floor_area == 100
-    assert isinstance(story.room_by_name('Office1'), Room2D) 
+    assert isinstance(story.room_by_identifier('Office1'), Room2D) 
     with pytest.raises(ValueError):
-        story.room_by_name('Office2')
+        story.room_by_identifier('Office2')
     story.add_room_2d(room2d_2)
     assert story.floor_area == 200
-    assert isinstance(story.room_by_name('Office2'), Room2D)
+    assert isinstance(story.room_by_identifier('Office2'), Room2D)
     with pytest.raises(ValueError):
-        story.room_by_name('Office3')
+        story.room_by_identifier('Office3')
     story.add_room_2ds([room2d_3, room2d_4])
     assert story.floor_area == 400
-    assert isinstance(story.room_by_name('Office3'), Room2D)
+    assert isinstance(story.room_by_identifier('Office3'), Room2D)
 
 
 def test_room2d_set_outdoor_window_shading_parameters():
@@ -101,11 +101,11 @@ def test_room2d_set_outdoor_window_shading_parameters():
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
     pts_4 = (Point3D(10, 10, 3), Point3D(10, 20, 3), Point3D(20, 20, 3), Point3D(20, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    room2d_3 = Room2D('Office 3', Face3D(pts_3), 3)
-    room2d_4 = Room2D('Office 4', Face3D(pts_4), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2, room2d_3, room2d_4])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    room2d_3 = Room2D('Office3', Face3D(pts_3), 3)
+    room2d_4 = Room2D('Office4', Face3D(pts_4), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2, room2d_3, room2d_4])
     story.solve_room_2d_adjacency(0.01)
 
     ashrae_base = SimpleWindowRatio(0.4)
@@ -126,9 +126,9 @@ def test_generate_grid():
     """Test the generate_grid method."""
     pts_1 = (Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(10, 10, 3), Point3D(10, 0, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
 
     mesh_grid = story.generate_grid(1)
     assert len(mesh_grid) == 2
@@ -142,9 +142,9 @@ def test_move():
     """Test the Story move method."""
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
 
     vec_1 = Vector3D(2, 2, 2)
     new_s = story.duplicate()
@@ -165,9 +165,9 @@ def test_scale():
     """Test the Room2D scale method."""
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
 
     new_s = story.duplicate()
     new_s.scale(2)
@@ -187,8 +187,8 @@ def test_rotate_xy():
     """Test the Story rotate_xy method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    room = Room2D('Square Shoebox', Face3D(pts, plane), 3)
-    story = Story('Office Floor', [room])
+    room = Room2D('SquareShoebox', Face3D(pts, plane), 3)
+    story = Story('OfficeFloor', [room])
     origin_1 = Point3D(1, 1, 0)
 
     test_1 = story.duplicate()
@@ -214,8 +214,8 @@ def test_reflect():
     """Test the Story reflect method."""
     pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
-    room = Room2D('Square Shoebox', Face3D(pts, plane), 3)
-    story = Story('Office Floor', [room])
+    room = Room2D('SquareShoebox', Face3D(pts, plane), 3)
+    story = Story('OfficeFloor', [room])
 
     origin_1 = Point3D(1, 0, 2)
     normal_1 = Vector3D(1, 0, 0)
@@ -235,9 +235,9 @@ def test_to_honeybee():
     """Test the to_honeybee method."""
     pts_1 = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 3)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 3)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
@@ -255,7 +255,7 @@ def test_to_honeybee():
     assert isinstance(hb_model.rooms[0][1].boundary_condition, Outdoors)
     assert isinstance(hb_model.rooms[0][2].boundary_condition, Surface)
     assert hb_model.rooms[0][2].boundary_condition.boundary_condition_object == \
-        hb_model.rooms[1][4].name
+        hb_model.rooms[1][4].identifier
     assert len(hb_model.rooms[0][1].apertures) == 1
     assert len(hb_model.rooms[0][2].apertures) == 0
 
@@ -264,9 +264,9 @@ def test_to_honeybee_different_heights():
     """Test the to_honeybee method with different floor and ceiling heights."""
     pts_1 = (Point3D(0, 0, 2), Point3D(10, 0, 2), Point3D(10, 10, 2), Point3D(0, 10, 2))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 5)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 5)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
@@ -291,17 +291,17 @@ def test_to_dict():
     """Test the Story to_dict method."""
     pts_1 = (Point3D(0, 0, 2), Point3D(10, 0, 2), Point3D(10, 10, 2), Point3D(0, 10, 2))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 5)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 5)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.set_outdoor_shading_parameters(Overhang(1))
 
     sd = story.to_dict()
     assert sd['type'] == 'Story'
-    assert sd['name'] == 'OfficeFloor'
-    assert sd['display_name'] == 'Office Floor'
+    assert sd['identifier'] == 'OfficeFloor'
+    assert sd['display_name'] == 'OfficeFloor'
     assert 'room_2ds' in sd
     assert len(sd['room_2ds']) == 2
     assert sd['floor_to_floor_height'] == 5
@@ -314,9 +314,9 @@ def test_to_from_dict():
     """Test the to/from dict of Story objects."""
     pts_1 = (Point3D(0, 0, 2), Point3D(10, 0, 2), Point3D(10, 10, 2), Point3D(0, 10, 2))
     pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
-    room2d_1 = Room2D('Office 1', Face3D(pts_1), 5)
-    room2d_2 = Room2D('Office 2', Face3D(pts_2), 3)
-    story = Story('Office Floor', [room2d_1, room2d_2])
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 5)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
     story.set_outdoor_shading_parameters(Overhang(1))

--- a/tests/windowparameter_test.py
+++ b/tests/windowparameter_test.py
@@ -64,7 +64,7 @@ def test_single_window_add_window_to_face():
     height = 3
     width = 10
     seg = LineSegment3D.from_end_points(Point3D(0, 0, 2), Point3D(width, 0, 2))
-    face = Face('test face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
+    face = Face('test_face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
     simple_window.add_window_to_face(face, 0.01)
 
     assert len(face.apertures) == 1
@@ -111,7 +111,7 @@ def test_simple_window_ratio_add_window_to_face():
     height = 3
     width = 10
     seg = LineSegment3D.from_end_points(Point3D(0, 0, 2), Point3D(width, 0, 2))
-    face = Face('test face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
+    face = Face('test_face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
     ashrae_base.add_window_to_face(face, 0.01)
 
     assert len(face.apertures) == 1
@@ -173,7 +173,7 @@ def test_repeating_window_ratio_add_window_to_face():
     height = 3
     width = 10
     seg = LineSegment3D.from_end_points(Point3D(0, 0, 2), Point3D(width, 0, 2))
-    face = Face('test face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
+    face = Face('test_face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
     ashrae_base.add_window_to_face(face, 0.01)
 
     assert len(face.apertures) == 3
@@ -235,7 +235,7 @@ def test_repeating_window_width_height_add_window_to_face():
     height = 3
     width = 10
     seg = LineSegment3D.from_end_points(Point3D(0, 0, 2), Point3D(width, 0, 2))
-    face = Face('test face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
+    face = Face('test_face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
     bod_windows.add_window_to_face(face, 0.01)
 
     assert len(face.apertures) == 4
@@ -323,7 +323,7 @@ def test_single_window_add_window_to_face():
     height = 3
     width = 10
     seg = LineSegment3D.from_end_points(Point3D(0, 0, 2), Point3D(width, 0, 2))
-    face = Face('test face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
+    face = Face('test_face', Face3D.from_extrusion(seg, Vector3D(0, 0, height)))
     detailed_window.add_window_to_face(face, 0.01)
 
     assert len(face.apertures) == 2


### PR DESCRIPTION
It took the whole day to get this together but honeybee_energy now uses "identifier" instead of "name".

This PR also adds a `user_data` key to all of the core objects.

The tests on this commit won't pass until the honeybee-core PR is merged in.

This PR should NOT be merged in until comparable PRs can be put together for the other 12 repos that are broken by this change.