### PR TITLE
fix(model): Remove north from Model properties

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-honeybee-core==1.28.0
+honeybee-core==1.28.3

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -24,7 +24,7 @@ import os
 
 
 def test_model_init():
-    """Test the initalization of Model objects and basic properties."""
+    """Test the initialization of Model objects and basic properties."""
     pts_1 = (Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(10, 10, 3), Point3D(10, 0, 3))
     pts_2 = (Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(20, 10, 3), Point3D(20, 0, 3))
     pts_3 = (Point3D(0, 10, 3), Point3D(0, 20, 3), Point3D(10, 20, 3), Point3D(10, 10, 3))
@@ -48,8 +48,6 @@ def test_model_init():
 
     assert model.identifier == 'New_Development'
     assert model.display_name == 'New_Development'
-    assert model.north_angle == 0
-    assert model.north_vector == Vector2D(0, 1)
     assert model.units == 'Meters'
     assert model.tolerance == 0
     assert model.angle_tolerance == 0
@@ -82,8 +80,6 @@ def test_model_properties_setability():
 
     model.display_name = 'TestBuilding'
     assert model.display_name == 'TestBuilding'
-    model.north_angle = 20
-    assert model.north_angle == 20
     model.units = 'Feet'
     assert model.units == 'Feet'
     model.tolerance = 0.01
@@ -118,10 +114,9 @@ def test_model_add_objects():
     tree_canopy_1 = ContextShade('TreeCanopy1', [tree_canopy_geo1])
     tree_canopy_2 = ContextShade('TreeCanopy2', [tree_canopy_geo2])
 
-    model = Model('NewDevelopment', [building_1], [tree_canopy_1], 15)
+    model = Model('NewDevelopment', [building_1], [tree_canopy_1])
     assert len(model.buildings) == 1
     assert len(model.context_shades) == 1
-    assert model.north_angle == 15
     with pytest.raises(AssertionError):
         model.add_building(tree_canopy_2)
     model.add_building(building_2)
@@ -165,8 +160,8 @@ def test_model_add_model():
     tree_canopy_1 = ContextShade('TreeCanopy1', [tree_canopy_geo1])
     tree_canopy_2 = ContextShade('TreeCanopy2', [tree_canopy_geo2])
 
-    model_1 = Model('NewDevelopment1', [building_1], [tree_canopy_1], 15)
-    model_2 = Model('NewDevelopment2', [building_2], [tree_canopy_2], 15)
+    model_1 = Model('NewDevelopment1', [building_1], [tree_canopy_1])
+    model_2 = Model('NewDevelopment2', [building_2], [tree_canopy_2])
 
     assert len(model_1.buildings) == 1
     assert len(model_1.context_shades) == 1
@@ -364,8 +359,8 @@ def test_check_duplicate_identifiers():
     tree_canopy_1 = ContextShade('TreeCanopy', [tree_canopy_geo1])
     tree_canopy_2 = ContextShade('TreeCanopy', [tree_canopy_geo2])
 
-    model_1 = Model('NewDevelopment1', [building_1], [tree_canopy_1], 15)
-    model_2 = Model('NewDevelopment2', [building_2], [tree_canopy_2], 15)
+    model_1 = Model('NewDevelopment1', [building_1], [tree_canopy_1])
+    model_2 = Model('NewDevelopment2', [building_2], [tree_canopy_2])
 
     assert model_1.check_duplicate_building_identifiers(False)
     assert model_1.check_duplicate_context_shade_identifiers(False)
@@ -473,7 +468,6 @@ def test_to_dict():
     tree_canopy = ContextShade('TreeCanopy', [tree_canopy_geo1, tree_canopy_geo2])
 
     model = Model('NewDevelopment', [building], [tree_canopy])
-    model.north_angle = 15
     model.tolerance = 0.01
     model.angle_tolerance = 1
 
@@ -485,8 +479,6 @@ def test_to_dict():
     assert len(model_dict['buildings']) == 1
     assert 'context_shades' in model_dict
     assert len(model_dict['context_shades']) == 1
-    assert 'north_angle' in model_dict
-    assert model_dict['north_angle'] == 15
     assert 'tolerance' in model_dict
     assert model_dict['tolerance'] == 0.01
     assert 'angle_tolerance' in model_dict
@@ -516,7 +508,6 @@ def test_to_from_dict_methods():
     tree_canopy = ContextShade('TreeCanopy', [tree_canopy_geo1, tree_canopy_geo2])
 
     model = Model('NewDevelopment', [building], [tree_canopy])
-    model.north_angle = 15
 
     model_dict = model.to_dict()
     new_model = Model.from_dict(model_dict)

--- a/tests/room2d_test.py
+++ b/tests/room2d_test.py
@@ -19,7 +19,7 @@ from ladybug_geometry.geometry3d.polyface import Polyface3D
 
 
 def test_room2d_init():
-    """Test the initalization of Room2D objects and basic properties."""
+    """Test the initialization of Room2D objects and basic properties."""
     pts = (Point3D(1, 1, 2), Point3D(1, 2, 2), Point3D(2, 2, 2), Point3D(2, 1, 2))
     plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
     room2d = Room2D('ZoneCLOSET920980', Face3D(pts, plane), 3)
@@ -53,7 +53,7 @@ def test_room2d_init():
 
 
 def test_room2d_init_with_windows():
-    """Test the initalization of Room2D objects with windows."""
+    """Test the initialization of Room2D objects with windows."""
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     ashrae_base = SimpleWindowRatio(0.4)
     overhang = Overhang(1)
@@ -82,7 +82,7 @@ def test_room2d_init_with_windows():
 
 
 def test_room_init_with_hole():
-    """Test the initalization of Room2D with a hole."""
+    """Test the initialization of Room2D with a hole."""
     bound_pts = [Point3D(0, 0), Point3D(3, 0), Point3D(3, 3), Point3D(0, 3)]
     hole_pts = [Point3D(1, 1, 0), Point3D(2, 1, 0), Point3D(2, 2, 0), Point3D(1, 2, 0)]
     face = Face3D(bound_pts, None, [hole_pts])
@@ -104,7 +104,7 @@ def test_room_init_with_hole():
 
 
 def test_room2d_init_invalid():
-    """Test the initalization of Room2D objects with invalid inputs."""
+    """Test the initialization of Room2D objects with invalid inputs."""
     pts = (Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3))
     ashrae_base = SimpleWindowRatio(0.4)
     overhang = Overhang(1)
@@ -138,7 +138,7 @@ def test_room2d_init_invalid():
 
 
 def test_room2d_init_clockwise():
-    """Test the initalization of Room2D objects with clockwise vertices."""
+    """Test the initialization of Room2D objects with clockwise vertices."""
     pts = (Point3D(0, 10, 3), Point3D(10, 10, 3), Point3D(10, 0, 3), Point3D(0, 0, 3))
     ashrae_base = SimpleWindowRatio(0.4)
     overhang = Overhang(1)
@@ -171,7 +171,7 @@ def test_room2d_init_clockwise():
 
 
 def test_room2d_init_from_polygon():
-    """Test the initalization of Room2D objects from a Polygon2D."""
+    """Test the initialization of Room2D objects from a Polygon2D."""
     pts = (Point2D(0, 0), Point2D(10, 0), Point2D(10, 10), Point2D(0, 10))
     polygon = Polygon2D(pts)
     ashrae_base = SimpleWindowRatio(0.4)
@@ -201,7 +201,7 @@ def test_room2d_init_from_polygon():
 
 
 def test_room2d_init_from_polygon_clockwise():
-    """Test the initalization of Room2D objects from a clockwise Polygon2D."""
+    """Test the initialization of Room2D objects from a clockwise Polygon2D."""
     pts_3d = (Point3D(0, 10, 3), Point3D(10, 10, 3), Point3D(10, 0, 3), Point3D(0, 0, 3))
     pts = (Point2D(0, 10), Point2D(10, 10), Point2D(10, 0), Point2D(0, 0))
     polygon = Polygon2D(pts)
@@ -220,7 +220,7 @@ def test_room2d_init_from_polygon_clockwise():
 
 
 def test_room2d_init_from_vertices():
-    """Test the initalization of Room2D objects from 2D vertices."""
+    """Test the initialization of Room2D objects from 2D vertices."""
     pts = (Point2D(0, 0), Point2D(10, 0), Point2D(10, 10), Point2D(0, 10))
     ashrae_base = SimpleWindowRatio(0.4)
     overhang = Overhang(1)


### PR DESCRIPTION
After some discussions with @mostaphaRoudsari , we have decided that the north should not be a property of the Model for the same reason why we don't have the location as a part of the model. The north direction is a property of the simulation assets like the skies used in Radiance or the simulation parameters used in our EnergyPlus.