### PR TITLE
fix(to_honeybee): Fix serialization of interior apertures to_honeybee

### DIFF
--- a/dragonfly/building.py
+++ b/dragonfly/building.py
@@ -510,11 +510,13 @@ class Building(_BaseGeometry):
                 floor_to_ceiling_height at which adjacent Faces will be split.
                 Default: 0.01, suitable for objects in meters.
         """
+        hb_rooms = []
         if use_multiplier:
-            hb_rooms = [room.to_honeybee(story.multiplier, tolerance)
-                        for story in self._unique_stories for room in story]
+            for story in self._unique_stories:
+                hb_rooms.extend(story.to_honeybee(True, tolerance))
         else:
-            hb_rooms = [room.to_honeybee(1, tolerance) for room in self.all_room_2ds()]
+            for story in self.all_stories():
+                hb_rooms.extend(story.to_honeybee(False, tolerance))
         hb_mod = Model(self.identifier, hb_rooms)
         hb_mod._display_name = self._display_name
         hb_mod._user_data = self._user_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-honeybee-core==1.29.0
+honeybee-core==1.30.0

--- a/tests/room2d_test.py
+++ b/tests/room2d_test.py
@@ -505,7 +505,7 @@ def test_to_honeybee():
     window = (ashrae_base, None, ashrae_base, None)
     shading = (overhang, None, None, None)
     room2d = Room2D('ZoneSHOE_BOX920980', Face3D(pts), 3, boundarycs, window, shading)
-    room = room2d.to_honeybee(1, 0.1)
+    room, adj = room2d.to_honeybee(1, 0.1)
 
     assert room.identifier == 'ZoneSHOE_BOX920980'
     assert room.display_name == 'ZoneSHOE_BOX920980'

--- a/tests/story_test.py
+++ b/tests/story_test.py
@@ -241,23 +241,22 @@ def test_to_honeybee():
     story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
 
-    hb_model = story.to_honeybee(0.01)
-    assert isinstance(hb_model, Model)
-    assert len(hb_model.rooms) == 2
-    assert len(hb_model.rooms[0]) == 6
-    assert hb_model.rooms[0].volume == 300
-    assert hb_model.rooms[0].floor_area == 100
-    assert hb_model.rooms[0].exterior_wall_area == 90
-    assert hb_model.rooms[0].exterior_aperture_area == pytest.approx(90 * 0.4, rel=1e-3)
-    assert hb_model.rooms[0].average_floor_height == 3
-    assert hb_model.rooms[0].check_solid(0.01, 1)
+    rooms = story.to_honeybee(0.01)
+    assert len(rooms) == 2
+    assert len(rooms[0]) == 6
+    assert rooms[0].volume == 300
+    assert rooms[0].floor_area == 100
+    assert rooms[0].exterior_wall_area == 90
+    assert rooms[0].exterior_aperture_area == pytest.approx(90 * 0.4, rel=1e-3)
+    assert rooms[0].average_floor_height == 3
+    assert rooms[0].check_solid(0.01, 1)
 
-    assert isinstance(hb_model.rooms[0][1].boundary_condition, Outdoors)
-    assert isinstance(hb_model.rooms[0][2].boundary_condition, Surface)
-    assert hb_model.rooms[0][2].boundary_condition.boundary_condition_object == \
-        hb_model.rooms[1][4].identifier
-    assert len(hb_model.rooms[0][1].apertures) == 1
-    assert len(hb_model.rooms[0][2].apertures) == 0
+    assert isinstance(rooms[0][1].boundary_condition, Outdoors)
+    assert isinstance(rooms[0][2].boundary_condition, Surface)
+    assert rooms[0][2].boundary_condition.boundary_condition_object == \
+        rooms[1][4].identifier
+    assert len(rooms[0][1].apertures) == 1
+    assert len(rooms[0][2].apertures) == 0
 
 
 def test_to_honeybee_different_heights():
@@ -267,24 +266,31 @@ def test_to_honeybee_different_heights():
     room2d_1 = Room2D('Office1', Face3D(pts_1), 5)
     room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
     story = Story('OfficeFloor', [room2d_1, room2d_2])
-    story.solve_room_2d_adjacency(0.01)
     story.set_outdoor_window_parameters(SimpleWindowRatio(0.4))
+    story.solve_room_2d_adjacency(0.01)
 
-    hb_model = story.to_honeybee(True, 0.01)
-    assert isinstance(hb_model, Model)
-    assert len(hb_model.rooms) == 2
-    assert len(hb_model.rooms[0]) == 8
-    assert hb_model.rooms[0].volume == 500
-    assert hb_model.rooms[0].floor_area == 100
-    assert hb_model.rooms[0].exterior_wall_area >= 150
-    assert hb_model.rooms[0].exterior_aperture_area == pytest.approx(150 * 0.4, rel=1e-3)
-    assert hb_model.rooms[0].average_floor_height == 2
-    assert hb_model.rooms[0].check_solid(0.01, 1)
+    rooms = story.to_honeybee(True, 0.01)
+    assert len(rooms) == 2
+    assert len(rooms[0]) == 8
+    assert rooms[0].volume == 500
+    assert rooms[0].floor_area == 100
+    assert rooms[0].exterior_wall_area >= 150
+    assert rooms[0].exterior_aperture_area == pytest.approx(150 * 0.4, rel=1e-3)
+    assert rooms[0].average_floor_height == 2
+    assert rooms[0].check_solid(0.01, 1)
 
-    assert isinstance(hb_model.rooms[0][1].boundary_condition, Outdoors)
-    assert not isinstance(hb_model.rooms[0][2].boundary_condition, Surface)  # bottom
-    assert isinstance(hb_model.rooms[0][3].boundary_condition, Surface)  # middle
-    assert not isinstance(hb_model.rooms[0][4].boundary_condition, Surface)  # top
+    assert isinstance(rooms[0][1].boundary_condition, Outdoors)
+    assert not isinstance(rooms[0][2].boundary_condition, Surface)  # bottom
+    assert isinstance(rooms[0][3].boundary_condition, Surface)  # middle
+    assert not isinstance(rooms[0][4].boundary_condition, Surface)  # top
+
+    assert len(rooms[0][3].apertures) == 1
+    assert len(rooms[1][4].apertures) == 1
+    rm1_ap = rooms[0][3].apertures[0]
+    rm2_ap = rooms[1][4].apertures[0]
+    assert isinstance(rm1_ap.boundary_condition, Surface)
+    assert isinstance(rm2_ap.boundary_condition, Surface)
+    assert rm1_ap.area == pytest.approx(rm2_ap.area, rel=1e-3)
 
 
 def test_to_dict():


### PR DESCRIPTION
This commit fixes a previous issue where the assignment of interior apertures was raising an error upon translation to honeybee. I finally just made the decision that adjacency-setting should be done on the level of the story's translation to honeybee rather than the Room2D's translation. This way, we can make sure that adjacent interior apertures are always set correctly. I imagine this will also help manage walls with an AirBoundary type as well.

I also added a small method that handles the case where adjacent segments have matching WindowParameters but offset floor/ceiling heights. This new method means that interior apertures are valid even in these offset cases. So, as long as the WindowParamters match between adjacent segments, all will be good.