### PR TITLE
fix(from_dict): Ensure correct reserilaization of adjacent BCs

### DIFF
--- a/dragonfly/room2d.py
+++ b/dragonfly/room2d.py
@@ -135,7 +135,6 @@ class Room2D(_BaseGeometry):
 
         # ensure all wall-assigned objects align with the geometry if it has been flipped
         if floor_geometry.normal.z < 0:
-
             new_bcs, new_win_pars, new_shd_pars = Room2D._flip_wall_assigned_objects(
                 floor_geometry, self._boundary_conditions, self._window_parameters,
                 self._shading_parameters)

--- a/tests/story_test.py
+++ b/tests/story_test.py
@@ -331,3 +331,35 @@ def test_to_from_dict():
     new_story = Story.from_dict(story_dict)
     assert isinstance(new_story, Story)
     assert new_story.to_dict() == story_dict
+
+
+def test_from_dict_reversed_surface_bcs():
+    """Test the from_dict of Story objects with reversed Surface boundary conditions."""
+    pts_1 = (Point3D(0, 0, 2), Point3D(10, 0, 2), Point3D(10, 10, 2), Point3D(0, 10, 2))
+    pts_2 = (Point3D(10, 0, 3), Point3D(20, 0, 3), Point3D(20, 10, 3), Point3D(10, 10, 3))
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 5)
+    room2d_2 = Room2D('Office2', Face3D(pts_2), 3)
+    story = Story('OfficeFloor', [room2d_1, room2d_2])
+    story.solve_room_2d_adjacency(0.01)
+    story_dict_original = story.to_dict()
+
+    # reverse the order of vertices in one of the rooms
+    story_dict = story.to_dict()
+    room2 = story_dict['room_2ds'][1]
+    room2['floor_boundary'] = list(reversed(room2['floor_boundary']))
+    room2['boundary_conditions'] = list(reversed(room2['boundary_conditions']))
+    room1_bc = story_dict['room_2ds'][0]['boundary_conditions'][1]
+    room1_bc['boundary_condition_objects'] = ('Office2..Face1', 'Office2')
+
+    new_story = Story.from_dict(story_dict)
+    assert new_story.to_dict() == story_dict_original
+
+    # reverse the order of vertices in both of the rooms
+    room1 = story_dict['room_2ds'][0]
+    room1['floor_boundary'] = list(reversed(room1['floor_boundary']))
+    room1['boundary_conditions'] = list(reversed(room1['boundary_conditions']))
+    room2_bc = story_dict['room_2ds'][1]['boundary_conditions'][0]
+    room2_bc['boundary_condition_objects'] = ('Office1..Face3', 'Office1')
+
+    new_story = Story.from_dict(story_dict)
+    assert new_story.to_dict() == story_dict_original


### PR DESCRIPTION
This commit fixes a bug that affects the case where Room2D floor_geometry vertices are not counter-clockwise in a JSON and they have Surface boundary conditions that reference other Room segments. Dragonfly automatically ensures that Room2D vertices are counterclockwise when it initializes the Room2D but this creates issues in the case of Surface boundary conditions since the adjacent segment is referenced by index and this index changes when the vertices are reversed.

So now we have a check that runs after Story serialization from_dict. This check determines if any Room2Ds have had their vertices reversed. If any of them have been reversed, it then looks through all of the boundary conditions and updates the Surface
boundary_condition_objects.

This will give me A LOT of peace of mind going forward.

Resolves https://github.com/ladybug-tools/dragonfly-core/issues/88