### PR TITLE
feat(writer): Add writer modules to all model objects

### DIFF
--- a/dragonfly/building.py
+++ b/dragonfly/building.py
@@ -6,6 +6,7 @@ from ._base import _BaseGeometry
 from .properties import BuildingProperties
 from .story import Story
 from .room2d import Room2D
+import dragonfly.writer.building as writer
 
 from honeybee.model import Model
 from honeybee.shade import Shade
@@ -579,6 +580,14 @@ class Building(_BaseGeometry):
         if self.user_data is not None:
             base['user_data'] = self.user_data
         return base
+
+    @property
+    def to(self):
+        """Building writer object.
+
+        Use this method to access Writer class to write the building in other formats.
+        """
+        return writer
 
     @staticmethod
     def buildings_to_honeybee(buildings, use_multiplier, tolerance=0.01):

--- a/dragonfly/context.py
+++ b/dragonfly/context.py
@@ -4,6 +4,7 @@ from __future__ import division
 
 from ._base import _BaseGeometry
 from .properties import ContextShadeProperties
+import dragonfly.writer.context as writer
 
 from honeybee.shade import Shade
 from honeybee.typing import clean_string
@@ -193,6 +194,14 @@ class ContextShade(_BaseGeometry):
         if self.user_data is not None:
             base['user_data'] = self.user_data
         return base
+
+    @property
+    def to(self):
+        """ContextShade writer object.
+
+        Use this method to access Writer class to write the context in other formats.
+        """
+        return writer
 
     def __copy__(self):
         new_shd = ContextShade(self.identifier, self._geometry)

--- a/dragonfly/room2d.py
+++ b/dragonfly/room2d.py
@@ -8,6 +8,7 @@ import dragonfly.windowparameter as glzpar
 from dragonfly.windowparameter import _WindowParameterBase, _AsymmetricBase
 import dragonfly.shadingparameter as shdpar
 from dragonfly.shadingparameter import _ShadingParameterBase
+import dragonfly.writer.room2d as writer
 
 from honeybee.typing import float_positive, clean_string
 import honeybee.boundarycondition as hbc
@@ -886,6 +887,14 @@ class Room2D(_BaseGeometry):
             base['user_data'] = self.user_data
 
         return base
+
+    @property
+    def to(self):
+        """Room2D writer object.
+
+        Use this method to access Writer class to write the room2d in other formats.
+        """
+        return writer
 
     @staticmethod
     def solve_adjacency(room_2ds, tolerance=0.01):

--- a/dragonfly/story.py
+++ b/dragonfly/story.py
@@ -5,6 +5,7 @@ from __future__ import division
 from ._base import _BaseGeometry
 from .properties import StoryProperties
 from .room2d import Room2D
+import dragonfly.writer.story as writer
 
 from honeybee.typing import float_positive, int_in_range, clean_string
 from honeybee.boundarycondition import boundary_conditions as bcs
@@ -616,6 +617,14 @@ using-multipliers-zone-and-or-window.html
         if self.user_data is not None:
             base['user_data'] = self.user_data
         return base
+
+    @property
+    def to(self):
+        """Story writer object.
+
+        Use this method to access Writer class to write the story in other formats.
+        """
+        return writer
 
     def __copy__(self):
         new_s = Story(self.identifier, tuple(room.duplicate() for room in self._room_2ds),

--- a/dragonfly/writer/__init__.py
+++ b/dragonfly/writer/__init__.py
@@ -1,0 +1,7 @@
+"""Geometry Writers.
+
+Note to developers:
+Use this package to extend honeybee's geometry writers for new extensions.
+Functions added to the respective module of a given geometry object
+will show up under the `to` method of the given object.
+"""

--- a/dragonfly/writer/building.py
+++ b/dragonfly/writer/building.py
@@ -1,0 +1,6 @@
+"""Building Writer.
+
+Note to developers:
+Use this module to extend dragonfly's Building writer for new extensions.
+(eg. adding `rad` to this module adds the method `Building.to.rad`)
+"""

--- a/dragonfly/writer/context.py
+++ b/dragonfly/writer/context.py
@@ -1,0 +1,6 @@
+"""ContextShade Writer.
+
+Note to developers:
+Use this module to extend dragonfly's ContextShade writer for new extensions.
+(eg. adding `rad` to this module adds the method `ContextShade.to.rad`)
+"""

--- a/dragonfly/writer/model.py
+++ b/dragonfly/writer/model.py
@@ -1,0 +1,6 @@
+"""Model Writer.
+
+Note to developers:
+Use this module to extend Dragonfly's Model writer for new extensions.
+(eg. adding `urbanopt` to this module adds the method `Model.to.urbanopt`)
+"""

--- a/dragonfly/writer/room2d.py
+++ b/dragonfly/writer/room2d.py
@@ -1,0 +1,6 @@
+"""Room2D Writer.
+
+Note to developers:
+Use this module to extend dragonfly's Room2D writer for new extensions.
+(eg. adding `rad` to this module adds the method `Room2D.to.rad`)
+"""

--- a/dragonfly/writer/story.py
+++ b/dragonfly/writer/story.py
@@ -1,0 +1,6 @@
+"""Story Writer.
+
+Note to developers:
+Use this module to extend dragonfly's Story writer for new extensions.
+(eg. adding `rad` to this module adds the method `Story.to.rad`)
+"""

--- a/tests/building_test.py
+++ b/tests/building_test.py
@@ -540,3 +540,13 @@ def test_to_from_dict():
     new_building = Building.from_dict(building_dict)
     assert isinstance(new_building, Building)
     assert new_building.to_dict() == building_dict
+
+
+def test_writer():
+    """Test the Building writer object."""
+    pts = (Point3D(50, 50, 3), Point3D(60, 50, 3), Point3D(60, 60, 3), Point3D(50, 60, 3))
+    bldg = Building.from_footprint('TestBldg', [Face3D(pts)], [5, 4, 3, 3], 0.01)
+
+    writers = [mod for mod in dir(bldg.to) if not mod.startswith('_')]
+    for writer in writers:
+        assert callable(getattr(bldg.to, writer))

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -142,3 +142,14 @@ def test_to_from_dict():
     new_context = ContextShade.from_dict(context_dict)
     assert isinstance(new_context, ContextShade)
     assert new_context.to_dict() == context_dict
+
+
+def test_writer():
+    """Test the Building writer object."""
+    tree_canopy_geo1 = Face3D.from_regular_polygon(6, 6, Plane(o=Point3D(5, -10, 6)))
+    tree_canopy_geo2 = Face3D.from_regular_polygon(6, 2, Plane(o=Point3D(-5, -10, 3)))
+    tree_canopy = ContextShade('Tree_Canopy', [tree_canopy_geo1, tree_canopy_geo2])
+
+    writers = [mod for mod in dir(tree_canopy.to) if not mod.startswith('_')]
+    for writer in writers:
+        assert callable(getattr(tree_canopy.to, writer))

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -615,3 +615,14 @@ def test_to_geojson():
     geo_fp = os.path.join(geojson_folder, model.identifier, '{}.geojson'.format(model.identifier))
     assert os.path.isfile(geo_fp)
     nukedir(os.path.join(geojson_folder, model.identifier), True)
+
+
+def test_writer():
+    """Test the Model writer object."""
+    pts = (Point3D(50, 50, 3), Point3D(60, 50, 3), Point3D(60, 60, 3), Point3D(50, 60, 3))
+    bldg = Building.from_footprint('TestBldg', [Face3D(pts)], [5, 4, 3, 3], 0.01)
+    model = Model('TestModel', [bldg])
+
+    writers = [mod for mod in dir(model.to) if not mod.startswith('_')]
+    for writer in writers:
+        assert callable(getattr(model.to, writer))

--- a/tests/room2d_test.py
+++ b/tests/room2d_test.py
@@ -579,3 +579,13 @@ def test_to_from_dict():
     new_room = Room2D.from_dict(room_dict)
     assert isinstance(new_room, Room2D)
     assert new_room.to_dict() == room_dict
+
+
+def test_writer():
+    """Test the Building writer object."""
+    pts_1 = (Point3D(0, 0, 2), Point3D(10, 0, 2), Point3D(10, 10, 2), Point3D(0, 10, 2))
+    room2d = Room2D('Office1', Face3D(pts_1), 5)
+
+    writers = [mod for mod in dir(room2d.to) if not mod.startswith('_')]
+    for writer in writers:
+        assert callable(getattr(room2d.to, writer))

--- a/tests/story_test.py
+++ b/tests/story_test.py
@@ -393,3 +393,14 @@ def test_from_dict_reversed_surface_bcs():
 
     new_story = Story.from_dict(story_dict)
     assert new_story.to_dict() == story_dict_original
+
+
+def test_writer():
+    """Test the Story writer object."""
+    pts_1 = (Point3D(0, 0, 2), Point3D(10, 0, 2), Point3D(10, 10, 2), Point3D(0, 10, 2))
+    room2d_1 = Room2D('Office1', Face3D(pts_1), 5)
+    story = Story('OfficeFloor', [room2d_1])
+
+    writers = [mod for mod in dir(story.to) if not mod.startswith('_')]
+    for writer in writers:
+        assert callable(getattr(story.to, writer))


### PR DESCRIPTION
This commit adds writer modules to all objects (Model, Building, Story, Room2D, ContextShade). I have been able to get away without these methods up to this point since all workflows have used the to_honeybee or to_dict methods.  But I can see that some specific writer methods will be useful in export to URBANopt and in future UWG export workflows.  I might also use these to add some direct-to-idf methods at some point.