### PR TITLE
style(model): Remove detailed_model_filename

### DIFF
--- a/dragonfly/model.py
+++ b/dragonfly/model.py
@@ -604,8 +604,6 @@ class Model(_BaseGeometry):
             feature_dict['properties']['number_of_stories_above_ground'] = \
                 bldg.story_count_above_ground
             feature_dict['properties']['type'] = 'Building'
-            feature_dict['properties']['detailed_model_filename'] = \
-                os.path.join(folder, bldg.identifier, 'OpenStudio', 'run', 'in.osm')
 
             # append the feature to the global dictionary
             geojson_dict['features'].append(feature_dict)


### PR DESCRIPTION
Now that the creation of this key is completely taken care of on the dragonfly-energy side of things, it's better to just not include it at all dragonfly-core, thereby avoiding potential mis-matches between this key and things happening with honeybee-energy.