### PR TITLE
fix(deps): bump honeybee-core from 1.32.0 to 1.32.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-honeybee-core==1.32.0
+honeybee-core==1.32.1
 ladybug-geometry-polyskel==1.2.0


### PR DESCRIPTION
It looks like I accidentally reverted this in my second-to-last commit.