### PR TITLE
fix(identifier): Allow identifier to be set by the user

### DIFF
--- a/dragonfly/_base.py
+++ b/dragonfly/_base.py
@@ -23,20 +23,24 @@ class _BaseGeometry(object):
 
     def __init__(self, identifier):
         """Initialize base object."""
-        self._identifier = valid_string(identifier, 'dragonfly object identifier')
+        self.identifier = identifier
         self._display_name = self._identifier
         self._properties = None
         self._user_data = None
 
     @property
     def identifier(self):
-        """Get a text string for the unique object identifer.
+        """Get or set a text string for the unique object identifer.
 
         This identifier remains constant as the object is mutated, copied, and
         serialized to different formats (eg. dict, idf, rad). This property is also
         used to reference the object across a Model.
         """
         return self._identifier
+
+    @identifier.setter
+    def identifier(self, value):
+        self._identifier = valid_string(value, 'dragonfly object identifier')
 
     @property
     def display_name(self):

--- a/dragonfly/model.py
+++ b/dragonfly/model.py
@@ -84,8 +84,7 @@ class Model(_BaseGeometry):
     def __init__(self, identifier, buildings=None, context_shades=None,
                  units='Meters', tolerance=0, angle_tolerance=0):
         """A collection of Buildings and ContextShades for an entire model."""
-        self._identifier = identifier
-        self._display_name = self._identifier
+        _BaseGeometry.__init__(self, identifier)  # process the identifier
         self.units = units
         self.tolerance = tolerance
         self.angle_tolerance = angle_tolerance
@@ -100,7 +99,6 @@ class Model(_BaseGeometry):
                 self.add_context_shade(shade)
 
         self._properties = ModelProperties(self)
-        self._user_data = None
 
     @classmethod
     def from_geojson(cls, geojson_file_path, location=None, point=Point2D(0, 0),


### PR DESCRIPTION
I originally had the property as read only in order to prevent the many cases where setting the identifier will break existing references across objects. But I think I have just come to realize that I can't stop people from playing with fire if they want to.  I guess people should be aware that re-setting a unique ID can have unintended consequences unless they know that they are doing.