### PR TITLE
fix(deps): Remove [cli] option in favor of making it a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,7 @@ Here are a number of frequently used extensions for Dragonfly:
 
 `pip install -U dragonfly-core`
 
-If you want to also include the command line interface use:
-
-`pip install -U dragonfly-core[cli]`
-
-To check if Dragonfly command line is installed correctly use `dragonfly viz` and you
+To check if Dragonfly command line interface is installed correctly use `dragonfly viz` and you
 should get a `viiiiiiiiiiiiizzzzzzzzz!` back in response!
 
 ## [API Documentation](https://www.ladybug.tools/dragonfly-core/docs/)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,9 +14,7 @@ Installation
 
 To install the core library use ``pip install -U dragonfly-core``.
 
-If you want to also include the command line interface use ``pip install -U dragonfly-core[cli]``.
-
-To check if the Dragonfly command line is installed correctly use ``dragonfly viz`` and you
+To check if the Dragonfly command line interface is installed correctly use ``dragonfly viz`` and you
 should get a ``viiiiiiiiiiiiizzzzzzzzz!`` back in response!
 
 

--- a/dragonfly/cli/__init__.py
+++ b/dragonfly/cli/__init__.py
@@ -44,13 +44,7 @@ Note:
     For extension with several commands you can use a folder structure instead of a single
     file.
 """
-
-try:
-    import click
-except ImportError:
-    raise ImportError(
-        'click module is not installed. Try `pip install dragonfly-core[cli]` command.'
-    )
+import click
 
 from dragonfly.cli.validate import validate
 from dragonfly.cli.translate import translate

--- a/dragonfly/cli/edit.py
+++ b/dragonfly/cli/edit.py
@@ -1,11 +1,9 @@
 """dragonfly model editing commands."""
-
-try:
-    import click
-except ImportError:
-    raise ImportError(
-        'click is not installed. Try `pip install . [cli]` command.'
-    )
+import click
+import sys
+import os
+import logging
+import json
 
 from dragonfly.model import Model
 from honeybee.boundarycondition import boundary_conditions as bcs
@@ -13,12 +11,6 @@ try:
     ad_bc = bcs.adiabatic
 except AttributeError:  # honeybee_energy is not loaded and adiabatic does not exist
     ad_bc = None
-
-
-import sys
-import os
-import logging
-import json
 
 _logger = logging.getLogger(__name__)
 

--- a/dragonfly/cli/translate.py
+++ b/dragonfly/cli/translate.py
@@ -1,20 +1,13 @@
 """dragonfly translation commands."""
-
-try:
-    import click
-except ImportError:
-    raise ImportError(
-        'click is not installed. Try `pip install . [cli]` command.'
-    )
-
-from ladybug.futil import preparedir
-from honeybee.config import folders as hb_folders
-from dragonfly.model import Model
-
+import click
 import sys
 import os
 import logging
 import json
+
+from ladybug.futil import preparedir
+from honeybee.config import folders as hb_folders
+from dragonfly.model import Model
 
 _logger = logging.getLogger(__name__)
 

--- a/dragonfly/cli/validate.py
+++ b/dragonfly/cli/validate.py
@@ -1,14 +1,5 @@
 """dragonfly validation commands."""
-
-try:
-    import click
-except ImportError:
-    raise ImportError(
-        'click is not installed. Try `pip install . [cli]` command.'
-    )
-
-from dragonfly.model import Model
-
+import click
 import sys
 import os
 import logging
@@ -16,11 +7,14 @@ import json
 
 _logger = logging.getLogger(__name__)
 
+from dragonfly.model import Model
+
 try:
     import dragonfly_schema.model as schema_model
 except ImportError:
     _logger.exception(
-        'dragonfly_schema is not installed. Try `pip install . [cli]` command.'
+        'dragonfly_schema is not installed and validation commands are unavailable.\n'
+        'You must use Python 3.7 or above to run validation commands.'
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 honeybee-core==1.42.3
+dragonfly-schema==1.6.32;python_version>='3.7'

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,6 @@ setuptools.setup(
     url="https://github.com/ladybug-tools/dragonfly-core",
     packages=setuptools.find_packages(exclude=["tests"]),
     install_requires=requirements,
-    extras_require={
-        'cli': ['click==7.1.2', "dragonfly-schema==1.6.32;python_version>='3.6'"]
-    },
     entry_points={
         "console_scripts": ["dragonfly = dragonfly.cli:main"]
     },


### PR DESCRIPTION
The click dependency is now specified all of the way down in ladybug-core. And we're changing dragonfly-schema to always be installed whenever someone is using Python 3.6 or above.