### PR TITLE
fix(story): Add option to bypass invalid adjacency in to_honeybee

### DIFF
--- a/dragonfly/cli/translate.py
+++ b/dragonfly/cli/translate.py
@@ -51,6 +51,11 @@ def translate():
               'units. If None, all other buildings will be included as context shade in '
               'each and every Model. Set to 0 to exclude all neighboring buildings '
               'from the resulting models.', type=str, default=None, show_default=True)
+@click.option('--enforce-adj-check/--bypass-adj-check', ' /-bc', help='Flag to note '
+              'whether an exception should be raised if an adjacency between two '
+              'Room2Ds is invalid or if the check should be bypassed and the invalid '
+              'Surface boundary condition should be replaced with an Outdoor boundary '
+              'condition.', default=True, show_default=True)
 @click.option('--folder', '-f', help='Folder on this computer, into which the HBJSON '
               'files will be written. If None, the files will be output '
               'to the honeybee default simulation folder and placed in a project '
@@ -62,7 +67,8 @@ def translate():
               'including their file paths. By default the list will be printed out to '
               'stdout', type=click.File('w'), default='-', show_default=True)
 def model_to_honeybee(model_json, obj_per_model, multiplier, no_plenum, no_cap,
-                      no_ceil_adjacency, shade_dist, folder, log_file):
+                      no_ceil_adjacency, shade_dist, enforce_adj_check,
+                      folder, log_file):
     """Translate a Dragonfly Model JSON file into several Honeybee Models.
 
     \b
@@ -86,7 +92,8 @@ def model_to_honeybee(model_json, obj_per_model, multiplier, no_plenum, no_cap,
         cap = not no_cap
         ceil_adjacency = not no_ceil_adjacency
         hb_models = model.to_honeybee(
-            obj_per_model, shade_dist, multiplier, add_plenum, cap, ceil_adjacency)
+            obj_per_model, shade_dist, multiplier, add_plenum, cap, ceil_adjacency,
+            enforce_adj=enforce_adj_check)
 
         # write out the honeybee JSONs and collect the info about them
         hb_jsons = []

--- a/dragonfly/model.py
+++ b/dragonfly/model.py
@@ -675,7 +675,7 @@ class Model(_BaseGeometry):
 
     def to_honeybee(self, object_per_model='Building', shade_distance=None,
                     use_multiplier=True, add_plenum=False, cap=False,
-                    solve_ceiling_adjacencies=False, tolerance=None):
+                    solve_ceiling_adjacencies=False, tolerance=None, enforce_adj=True):
         """Convert Dragonfly Model to an array of Honeybee Models.
 
         Args:
@@ -723,7 +723,11 @@ class Model(_BaseGeometry):
                 floor_to_ceiling_height at which adjacent Faces will be split.
                 This is also used in the generation of Windows. This must be a
                 positive, non-zero number. If None, the Model's own tolerance
-                will be used. Default: None.
+                will be used. (Default: None).
+            enforce_adj: Boolean to note whether an exception should be raised if
+                an adjacency between two Room2Ds is invalid (True) or if the invalid
+                Surface boundary condition should be replaced with an Outdoor
+                boundary condition (False). (Default: True).
 
         Returns:
             An array of Honeybee Models that together represent this Dragonfly Model.
@@ -740,14 +744,17 @@ class Model(_BaseGeometry):
         elif object_per_model is None or object_per_model.title() == 'Building':
             models = Building.buildings_to_honeybee(
                 self._buildings, self._context_shades, shade_distance,
-                use_multiplier, add_plenum, cap, tolerance=tolerance)
+                use_multiplier, add_plenum, cap, tolerance=tolerance,
+                enforce_adj=enforce_adj)
         elif object_per_model.title() == 'Story':
             models = Building.stories_to_honeybee(
                 self._buildings, self._context_shades, shade_distance,
-                use_multiplier, add_plenum, cap, tolerance=tolerance)
+                use_multiplier, add_plenum, cap, tolerance=tolerance,
+                enforce_adj=enforce_adj)
         elif object_per_model.title() == 'District':
             models = [Building.district_to_honeybee(
-                self._buildings, use_multiplier, add_plenum, tolerance=tolerance)]
+                self._buildings, use_multiplier, add_plenum, tolerance=tolerance,
+                enforce_adj=enforce_adj)]
             for shd_group in self._context_shades:
                 for shd in shd_group.to_honeybee():
                     for model in models:


### PR DESCRIPTION
The new option allows invalid Surface boundary conditions to be replaced with Outdoor ones upon translation to honeybee instead of raising an exception.