### PR TITLE
fix(room2d): Improve the reset-room-boundaries command

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -52,7 +52,6 @@ def test_reset_room_boundaries():
     runner = CliRunner()
     cmds = [input_model, input_pgons, '--output-file', output_model]
     result = runner.invoke(reset_room_boundaries, cmds)
-    print(result.output)
     assert result.exit_code == 0
 
     assert os.path.isfile(output_model)


### PR DESCRIPTION
It can now control floor heights and takes default properties from the largest of the Room2Ds in each Polygon2D.