### PR TITLE
fix(base): Get default state of display_name to last through duplication

### DIFF
--- a/dragonfly/_base.py
+++ b/dragonfly/_base.py
@@ -191,7 +191,7 @@ class _BaseGeometry(object):
 
     def __copy__(self):
         new_obj = self.__class__(self.identifier)
-        new_obj._display_name = self.display_name
+        new_obj._display_name = self._display_name
         new_obj._user_data = None if self.user_data is None else self.user_data.copy()
         return new_obj
 

--- a/dragonfly/building.py
+++ b/dragonfly/building.py
@@ -124,7 +124,7 @@ class Building(_BaseGeometry):
                     for j, room in enumerate(rooms):
                         room.move(move_vec)
                         room.floor_to_ceiling_height = flr_hgt
-                        room._identifier = \
+                        room.identifier = \
                             '{}_Floor{}_Room{}'.format(identifier, i + 1, j + 1)
                     if perimeter_offset != 0:  # reset all boundary conditions
                         for room in rooms:
@@ -515,8 +515,9 @@ class Building(_BaseGeometry):
                 that this prefix be short to avoid maxing out the 100 allowable
                 characters for dragonfly identifiers.
         """
-        self._identifier = clean_string('{}_{}'.format(prefix, self.identifier))
-        self.display_name = '{}_{}'.format(prefix, self.display_name)
+        self.identifier = clean_string('{}_{}'.format(prefix, self.identifier))
+        if self._display_name is not None:
+            self.display_name = '{}_{}'.format(prefix, self.display_name)
         self.properties.add_prefix(prefix)
         for story in self.unique_stories:
             story.add_prefix(prefix)
@@ -1214,7 +1215,7 @@ class Building(_BaseGeometry):
     def __copy__(self):
         new_b = Building(self.identifier,
                          tuple(story.duplicate() for story in self._unique_stories))
-        new_b._display_name = self.display_name
+        new_b._display_name = self._display_name
         new_b._user_data = None if self.user_data is None else self.user_data.copy()
         new_b._properties._duplicate_extension_attr(self._properties)
         return new_b

--- a/dragonfly/building.py
+++ b/dragonfly/building.py
@@ -797,18 +797,18 @@ class Building(_BaseGeometry):
             # then, loop through the story Room2Ds and set properties of relevant walls
             for story in bldg.unique_stories:
                 for rm in story.room_2ds:
-                    zip_obj = zip(rm.boundary_conditions, rm.window_parameters,
-                                  rm.floor_segments_2d, rm.segment_normals)
+                    zip_obj = zip(
+                        rm.boundary_conditions, rm.floor_segments_2d, rm.segment_normals)
                     new_bcs = list(rm.boundary_conditions)
                     new_win_pars = list(rm.window_parameters)
-                    for k, (bc, wp, seg, normal) in enumerate(zip_obj):
+                    for k, (bc, seg, normal) in enumerate(zip_obj):
                         if not isinstance(bc, Outdoors):  # nothing to change
                             continue
                         seg_mid = seg.midpoint.move(normal * -tolerance)
                         seg_ray = LineSegment2D.from_sdl(seg_mid, normal, distance)
                         for rel_poly, rel_hgt in zip(rel_polys, rel_heights):
-                            if story.floor_height > rel_hgt:  # story above other bldg
-                                continue  # we can ignore this one
+                            if story.floor_height >= rel_hgt - tolerance:
+                                continue  # story above other bldg; we can ignore it
                             for o_poly in rel_poly:
                                 if len(o_poly.intersect_line_ray(seg_ray)) > 0:
                                     # we have found an alleyway!

--- a/dragonfly/room2d.py
+++ b/dragonfly/room2d.py
@@ -771,7 +771,8 @@ class Room2D(_BaseGeometry):
                 characters for dragonfly identifiers.
         """
         self._identifier = clean_string('{}_{}'.format(prefix, self.identifier))
-        self.display_name = '{}_{}'.format(prefix, self.display_name)
+        if self._display_name is not None:
+            self.display_name = '{}_{}'.format(prefix, self.display_name)
         self.properties.add_prefix(prefix)
         for i, bc in enumerate(self._boundary_conditions):
             if isinstance(bc, Surface):
@@ -1180,7 +1181,7 @@ class Room2D(_BaseGeometry):
 
         # assign overall properties to the rebuilt room
         rebuilt_room._skylight_parameters = self._skylight_parameters
-        rebuilt_room._display_name = self.display_name
+        rebuilt_room._display_name = self._display_name
         rebuilt_room._user_data = self._user_data
         rebuilt_room._parent = self._parent
         rebuilt_room._properties._duplicate_extension_attr(self._properties)
@@ -1300,7 +1301,7 @@ class Room2D(_BaseGeometry):
             new_shd, self.is_ground_contact, self.is_top_exposed)
         rebuilt_room._air_boundaries = new_abs
         rebuilt_room._skylight_parameters = self._skylight_parameters
-        rebuilt_room._display_name = self.display_name
+        rebuilt_room._display_name = self._display_name
         rebuilt_room._user_data = self._user_data
         rebuilt_room._parent = self._parent
         rebuilt_room._properties._duplicate_extension_attr(self._properties)
@@ -1877,7 +1878,7 @@ class Room2D(_BaseGeometry):
                 is_ground_contact=room_2ds[i].is_ground_contact,
                 is_top_exposed=room_2ds[i].is_top_exposed)
             rebuilt_room._skylight_parameters = room_2ds[i].skylight_parameters
-            rebuilt_room._display_name = room_2ds[i].display_name
+            rebuilt_room._display_name = room_2ds[i]._display_name
             rebuilt_room._user_data = None if room_2ds[i].user_data is None else \
                 room_2ds[i].user_data.copy()
             rebuilt_room._parent = room_2ds[i]._parent
@@ -2928,7 +2929,7 @@ class Room2D(_BaseGeometry):
         new_r = Room2D(self.identifier, self._floor_geometry,
                        self.floor_to_ceiling_height,
                        self._boundary_conditions[:])  # copy boundary condition list
-        new_r._display_name = self.display_name
+        new_r._display_name = self._display_name
         new_r._user_data = None if self.user_data is None else self.user_data.copy()
         new_r._parent = self._parent
         new_r._window_parameters = self._window_parameters[:]  # copy window list

--- a/dragonfly/story.py
+++ b/dragonfly/story.py
@@ -596,7 +596,8 @@ using-multipliers-zone-and-or-window.html
                 characters for dragonfly identifiers.
         """
         self._identifier = clean_string('{}_{}'.format(prefix, self.identifier))
-        self.display_name = '{}_{}'.format(prefix, self.display_name)
+        if self._display_name is not None:
+            self.display_name = '{}_{}'.format(prefix, self.display_name)
         self.properties.add_prefix(prefix)
         for room in self.room_2ds:
             room.add_prefix(prefix)
@@ -1087,7 +1088,7 @@ using-multipliers-zone-and-or-window.html
                         is_ground_contact=room.is_ground_contact,
                         is_top_exposed=room.is_top_exposed)
                     room._match_and_transfer_wall_props(new_room, tolerance)
-                    new_room._display_name = room.display_name
+                    new_room._display_name = room._display_name
                     new_room._user_data = None if room.user_data is None \
                         else room.user_data.copy()
                     new_room._skylight_parameters = room._skylight_parameters
@@ -1578,7 +1579,7 @@ using-multipliers-zone-and-or-window.html
             self.identifier, tuple(room.duplicate() for room in self._room_2ds),
             self._floor_to_floor_height, self._floor_height, self._multiplier)
         new_s._roof = None if self._roof is None else self._roof.duplicate()
-        new_s._display_name = self.display_name
+        new_s._display_name = self._display_name
         new_s._user_data = None if self.user_data is None else self.user_data.copy()
         new_s._parent = self._parent
         new_s._properties._duplicate_extension_attr(self._properties)


### PR DESCRIPTION
This was causing some bugs in cases where we try to generate something unique form the display_name. Like Sensor Grids here:

https://discourse.ladybug.tools/t/dragonfly-creating-duplicate-room-ids-that-mess-up-daylight-sensor-grids/22703/2