### PR TITLE
fix(skylight): Fix bug in previous commit

### DIFF
--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -558,7 +558,7 @@ def test_to_honeybee_doors_skylights_roof():
     skylights = [
         f.apertures for f in hb_models[0].faces
         if isinstance(f.type, RoofCeiling) and len(f.apertures) != 0]
-    assert len(skylights) == 3
+    assert len(skylights) == 2
     assert len(skylights[0]) == 1
 
     int_doors = [


### PR DESCRIPTION
This ensure that, when there are two roof polygons above a Room2D, they only get added to one of them.