### PR TITLE
fix(room2d): Add methods to assign air boundaries to adjacencies

### DIFF
--- a/dragonfly/story.py
+++ b/dragonfly/story.py
@@ -1136,6 +1136,40 @@ using-multipliers-zone-and-or-window.html
             self._room_2ds = Room2D.intersect_adjacency(self._room_2ds, tolerance)
         Room2D.solve_adjacency(self._room_2ds, tolerance, resolve_window_conflicts)
 
+    def set_adjacent_air_boundary(self, room_ids=None, guide_lines=None, tolerance=0.01):
+        """Set adjacencies between Room2Ds in this Story to use air boundaries.
+
+        Args:
+            room_ids: An optional list of Room2D identifiers to specify a subset
+                of rooms within the Story that will have air boundaries set
+                between them. If None, all Room2Ds in the story will have
+                air boundaries set if they are adjacent to another. (Default: None).
+            guide_lines: An optional list of LineSegment2Ds to specify a subset
+                of rooms within the Story that will have air boundaries set
+                between them. If None, all Room2Ds in the story will have
+                air boundaries set if they are adjacent to another. (Default: None).
+            tolerance: The minimum difference between the coordinate values of two
+                faces at which they can be considered adjacent. (Default: 0.01,
+                suitable for objects in meters).
+        """
+        # gather all of the Room2Ds which will have air boundaries assigned
+        rooms = self._room_2ds if room_ids is None \
+            else self.rooms_by_identifier(room_ids)
+        # find the adjacencies along which air boundaries will be set
+        if guide_lines is None or len(guide_lines) == 0:
+            adj_info = Room2D.find_adjacency(rooms, tolerance)
+        else:
+            adj_info = Room2D.find_adjacency_by_guide_lines(
+                rooms, guide_lines, tolerance)
+        # assign air boundaries to all of the pairs that were found
+        for room_pair in adj_info:
+            for room_adj in room_pair:
+                room, wall_i = room_adj
+                try:
+                    room.set_air_boundary(wall_i)
+                except AssertionError:  # segment with windows or non-adjacent BC
+                    pass  # ignore this particular segment
+
     def set_outdoor_window_parameters(self, window_parameter):
         """Set all of the outdoor walls to have the same window parameters.
 

--- a/tests/projection_test.py
+++ b/tests/projection_test.py
@@ -71,4 +71,3 @@ def test_lon_lat_to_polygon():
     for point, test_point in zip(polygon, test_polygon):
         assert test_point[0] == pytest.approx(point[0], abs=1e-5)
         assert test_point[1] == pytest.approx(point[1], abs=1e-5)
-

--- a/tests/roof_test.py
+++ b/tests/roof_test.py
@@ -64,6 +64,24 @@ def test_resolved_geometry():
     assert res_geo[2].center.z == pytest.approx(0.0, abs=1e-3)
 
 
+def test_roof_find_gaps():
+    """Test the RoofSpecification.find_gaps method."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(10, 0, 0), Point3D(10, 5, 5), Point3D(0, 5, 5))
+    pts_2 = (Point3D(0, 5, 5), Point3D(10, 5, 5), Point3D(10, 10, 0), Point3D(0, 10, 0))
+    pts_3 = (Point3D(0, 0, 0), Point3D(10, -0, 0), Point3D(10, -5, 0), Point3D(0, -5, 0))
+    pts_4 = (Point3D(0, -0.05, 0), Point3D(10, 0, 0), Point3D(10, -5, 0), Point3D(0, -5, 0))
+    pts_5 = (Point3D(0, -0.05, 0), Point3D(10, -0.05, 0), Point3D(10, -5, 0), Point3D(0, -5, 0))
+
+    roof1 = RoofSpecification([Face3D(pts_1), Face3D(pts_2), Face3D(pts_3)])
+    assert len(roof1.find_gaps(0.1)) == 0
+
+    roof2 = RoofSpecification([Face3D(pts_1), Face3D(pts_2), Face3D(pts_4)])
+    assert len(roof2.find_gaps(0.1)) == 2
+
+    roof3 = RoofSpecification([Face3D(pts_1), Face3D(pts_2), Face3D(pts_5)])
+    assert len(roof3.find_gaps(0.1)) == 4
+
+
 def test_move():
     """Test the RoofSpecification move method."""
     pts_1 = (Point3D(0, 2, 0), Point3D(2, 2, 0), Point3D(2, 0, 0), Point3D(0, 0, 0))


### PR DESCRIPTION
These will be used in the model editor to give users a level of control over how air boundaries are assigned.